### PR TITLE
switch to new Bitbucket host keys

### DIFF
--- a/images/Dockerfile.build-go
+++ b/images/Dockerfile.build-go
@@ -24,7 +24,7 @@ ENV GOCACHE /tmp
 
 # set up private repo access for go mod
 RUN git config --system url."git@bitbucket.org:".insteadOf "https://bitbucket.org/"
-RUN ssh-keyscan -H bitbucket.org | tee -a /etc/ssh/ssh_known_hosts
+RUN ssh-keyscan -t Ed25519 -H bitbucket.org | tee -a /etc/ssh/ssh_known_hosts
 ENV GOPRIVATE bitbucket.org/luthersystems
 
 ENTRYPOINT ["tini", "--", "make", "-f", "/opt/Dockerfile.go.mk"]

--- a/images/Dockerfile.build-godynamic
+++ b/images/Dockerfile.build-godynamic
@@ -68,7 +68,7 @@ ENV GOCACHE /tmp
 
 # set up private repo access for go mod
 RUN git config --system url."git@bitbucket.org:".insteadOf "https://bitbucket.org/"
-RUN ssh-keyscan -H bitbucket.org | tee -a /etc/ssh/ssh_known_hosts
+RUN ssh-keyscan -t Ed25519 -H bitbucket.org | tee -a /etc/ssh/ssh_known_hosts
 ENV GOPRIVATE bitbucket.org/luthersystems
 
 ENTRYPOINT ["tini", "--", "make", "-f", "/opt/Dockerfile.godynamic.mk"]

--- a/images/Dockerfile.build-goextra
+++ b/images/Dockerfile.build-goextra
@@ -24,7 +24,7 @@ ENV GOCACHE /tmp
 
 # set up private repo access for go mod
 RUN git config --system url."git@bitbucket.org:".insteadOf "https://bitbucket.org/"
-RUN ssh-keyscan -H bitbucket.org | tee -a /etc/ssh/ssh_known_hosts
+RUN ssh-keyscan -t Ed25519 -H bitbucket.org | tee -a /etc/ssh/ssh_known_hosts
 ENV GOPRIVATE bitbucket.org/luthersystems
 
 ENTRYPOINT ["tini", "--", "make", "-f", "/opt/Dockerfile.goextra.mk"]


### PR DESCRIPTION
This switches the Bitbucket host keys to the new Ed25519 keys in response to a recent Bitbucket incident:
https://bitbucket.org/blog/ssh-host-key-changes