### PR TITLE
Use docker buildx instead of legacy docker build

### DIFF
--- a/images/build-go.mk
+++ b/images/build-go.mk
@@ -10,7 +10,7 @@ DOCKER=docker
 .PHONY: static
 static: build
 	@echo "Static ${STATIC_IMAGE}"
-	${DOCKER} build \
+	${DOCKER} buildx build --load \
 		--build-arg BIN=$(notdir ${BIN}) \
 		-t ${STATIC_IMAGE}:latest \
 		-t ${STATIC_IMAGE}:${VERSION} \

--- a/images/build-godynamic.mk
+++ b/images/build-godynamic.mk
@@ -10,7 +10,7 @@ DOCKER=docker
 .PHONY: dynamic
 dynamic: build
 	@echo "Dynamic ${STATIC_IMAGE}"
-	${DOCKER} build \
+	${DOCKER} buildx build --load \
 		--build-arg BIN=$(notdir ${BIN}) \
 		-t ${STATIC_IMAGE}:latest \
 		-t ${STATIC_IMAGE}:${VERSION} \

--- a/images/build-java.mk
+++ b/images/build-java.mk
@@ -3,7 +3,7 @@ DOCKER=docker
 .PHONY: static
 static:
 	@echo "Static ${STATIC_IMAGE}"
-	${DOCKER} build \
+	${DOCKER} buildx build --load \
 		--build-arg BIN=$(notdir ${BIN}) \
 		-t ${STATIC_IMAGE}:latest \
 		-t ${STATIC_IMAGE}:${VERSION} \

--- a/images/build-js.mk
+++ b/images/build-js.mk
@@ -3,7 +3,7 @@ DOCKER=docker
 .PHONY: static
 static: build
 	@echo "Static ${STATIC_IMAGE}"
-	${DOCKER} build \
+	${DOCKER} buildx build --load \
 		-t ${STATIC_IMAGE}:latest \
 		-t ${STATIC_IMAGE}:${VERSION} \
 		-f -  . < /opt/Dockerfile.js.static


### PR DESCRIPTION
## Problem
The build Makefiles use the deprecated `docker build` command which shows warnings:
```
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
```

## Solution
- Replace `docker build` with `docker buildx build --load` in all build Makefiles
- Updated: build-go.mk, build-java.mk, build-js.mk, build-godynamic.mk
- `--load` flag loads the image into local Docker daemon (required for buildx)

## Testing
- [ ] Static builds should work without deprecation warnings
- [ ] Images should be built and loaded correctly