### PR TITLE
chore: SHA-pin Actions and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           - multi-build-java
           - multi-build-js
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Build container
         uses: ./.github/actions/build-docker-images
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           - multi-build-java
           - multi-build-js
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Build & push container
         uses: ./.github/actions/build-docker-images
         with:
@@ -40,10 +40,10 @@ jobs:
       - build
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Configure DockerHub
         uses: ./.github/actions/configure-dockerhub
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
       - name: Create and push manifest for multiarch
         run: cd images && make push-manifests GIT_TAG=$GITHUB_REF_NAME


### PR DESCRIPTION
## Summary

Part of the org hardening initiative (luthersystems/infosec#1).

### 1. Pin every external Action to a commit SHA

Replaces `uses: foo/bar@v4` with `uses: foo/bar@<sha>  # v4`. Defends against the tj-actions/changed-files class of attack, where a compromised maintainer can retroactively repoint a version tag to a malicious commit. SHA pins are immutable; tag pins are not.

Pinned in this PR:
- `actions/checkout@v5` → `93cb6ef` (# `v5`)
- `docker/setup-buildx-action@v4` → `4d04d5d` (# `v4`)

### 2. Add `.github/dependabot.yml`

Enables the `github-actions` ecosystem updater with grouped weekly updates. Dependabot auto-bumps SHAs (and updates the trailing version comments) every Monday, so pins stay current without manual maintenance.

Phase 1 only — the `github-actions` ecosystem. Runtime ecosystem (npm/pip/gomod) will be added per repo in Phase 2, once CI is confirmed green.

## Test plan

- [ ] CI passes (Actions resolve correctly with the SHA pins).
- [ ] After merge, confirm Dependabot picks up the new config.
