### PR TITLE
chore: drop vestigial multi-build-* matrix targets (phase 0 of #3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,15 @@ jobs:
           - amd64
           - arm64
         image:
-          - build-go-alpine
-          - service-base-alpine
-          - nginx-frontend
           - build-api
+          - build-go
+          - build-go-alpine
+          - build-godynamic
+          - build-java
+          - build-js
           - build-swaggercodegen
-          - multi-build-go
-          - multi-build-godynamic
-          - multi-build-java
-          - multi-build-js
+          - nginx-frontend
+          - service-base-alpine
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build container

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,15 @@ jobs:
           - amd64
           - arm64
         image:
-          - build-go-alpine
-          - service-base-alpine
-          - nginx-frontend
           - build-api
+          - build-go
+          - build-go-alpine
+          - build-godynamic
+          - build-java
+          - build-js
           - build-swaggercodegen
-          - multi-build-go
-          - multi-build-godynamic
-          - multi-build-java
-          - multi-build-js
+          - nginx-frontend
+          - service-base-alpine
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build & push container

--- a/images/Makefile
+++ b/images/Makefile
@@ -4,9 +4,17 @@ include ${COMMON_MAKEFILE}
 CONFIG_MAKEFILE=${PROJECT_DIR}/common.config.mk
 include ${CONFIG_MAKEFILE}
 
-IMAGES=luthersystems/build-go-alpine luthersystems/service-base-alpine luthersystems/build-api luthersystems/build-swaggercodegen luthersystems/nginx-frontend
-MULTI_STAGE_IMAGES=luthersystems/build-go luthersystems/build-godynamic luthersystems/build-java luthersystems/build-js
-ALL_IMAGES=${IMAGES} ${MULTI_STAGE_IMAGES}
+IMAGES= \
+	luthersystems/build-api \
+	luthersystems/build-go \
+	luthersystems/build-go-alpine \
+	luthersystems/build-godynamic \
+	luthersystems/build-java \
+	luthersystems/build-js \
+	luthersystems/build-swaggercodegen \
+	luthersystems/nginx-frontend \
+	luthersystems/service-base-alpine
+ALL_IMAGES=${IMAGES}
 
 TAG_SUFFIX=
 DOCKER_BUILDX_OPTS=$(if $(GIT_TAG),--push,)
@@ -19,7 +27,7 @@ BUILDX_CACHE_FLAGS ?=
 .SECONDARY:
 
 .PHONY:
-IMAGE_DUMMYS := $(foreach I,$(IMAGES),$(call IMAGE_DUMMY,$I)) $(foreach I,$(MULTI_STAGE_IMAGES),$(call IMAGE_DUMMY,multi-${I}))
+IMAGE_DUMMYS := $(foreach I,$(IMAGES),$(call IMAGE_DUMMY,$I))
 PUSH_DUMMYS := $(foreach I,$(ALL_IMAGES),$(call PUSH_DUMMY,$I))
 
 .PHONY: default
@@ -34,12 +42,6 @@ clean:
 	${RM} -rf _build
 
 %: $(call IMAGE_DUMMY,luthersystems/%)
-	@
-
-multi-%: $(call IMAGE_DUMMY,multi-luthersystems/%)
-	@
-
-$(call IMAGE_DUMMY,multi-luthersystems/%): Dockerfile.%.static %.mk $(call IMAGE_DUMMY,luthersystems/%)
 	@
 
 $(call IMAGE_DUMMY,luthersystems/%): Dockerfile.% Makefile ${COMMON_MAKEFILE} ${CONFIG_MAKEFILE} $(call DUMMY_TARGET,deps,luthersystems/%)
@@ -75,10 +77,21 @@ $(call DUMMY_TARGET,deps,luthersystems/build-api): build-api.mk
 $(call DUMMY_TARGET,deps,luthersystems/build-swaggercodegen): build-swaggercodegen.mk
 	@
 
-$(call DUMMY_TARGET,deps,luthersystems/build-go):
+# The four builder images below COPY their corresponding Dockerfile.X.static
+# and build-X.mk into the image (consumed downstream by `make static`).
+# Declaring them as deps ensures the builder image rebuilds when either
+# input changes. Slated for removal once the embedded static-image flow
+# is retired (tracked in #3).
+$(call DUMMY_TARGET,deps,luthersystems/build-go): build-go.mk Dockerfile.build-go.static
 	@
 
-$(call DUMMY_TARGET,deps,luthersystems/build-go-alpine):
+$(call DUMMY_TARGET,deps,luthersystems/build-godynamic): build-godynamic.mk Dockerfile.build-godynamic.static
+	@
+
+$(call DUMMY_TARGET,deps,luthersystems/build-java): build-java.mk Dockerfile.build-java.static
+	@
+
+$(call DUMMY_TARGET,deps,luthersystems/build-js): build-js.mk Dockerfile.build-js.static
 	@
 
 $(call PUSH_DUMMY,luthersystems/%):


### PR DESCRIPTION
## Summary
- `multi-build-*` targets were a Makefile/workflow naming artifact; they only existed to thread `Dockerfile.X.static` + `build-X.mk` as a dep edge to the underlying `build-X` image build. They never produced a distinct Docker Hub image, and no downstream consumer in the luthersystems org references `luthersystems/multi-build-*`.
- Verified with `gh search code 'multi-build-go' --owner luthersystems` — hits only in this repo's own workflows.
- Matrix shrinks from 9 entries to 9 with cleaner names (`build-go` instead of `multi-build-go`). Behavior is unchanged: same Docker Hub tags get pushed (`luthersystems/build-go:VERSION` etc).
- The Make dep edge for `.static` + `.mk` files is preserved by adding explicit per-image deps under the existing deps-dummy pattern, matching how `build-api` and `build-swaggercodegen` already declare their `.mk` dep.

## Why now
First step of the larger buildenv retool tracked in #3. Zero downstream impact, removes a layer of indirection that obscures what the rest of the retool actually has to do.

## Test plan
- [ ] CI matrix runs all 9 image builds × 2 arches green on this PR (proves the renamed targets resolve)
- [ ] Verify `luthersystems/build-go` etc. still get pushed correctly on the next tag release (publish.yml unchanged behavior)
- [ ] No consumer repo notices anything (no `multi-build-*` references exist outside this repo)

## Out of scope
- Removing `Dockerfile.X.static` + `build-X.mk` files (phase 2 of #3)
- Migrating downstream consumers off `make static` (separate per-consumer PRs)
- Deleting the `luthersystems/multi-build-*` Docker Hub repos — they don't exist as separate repos; this is purely workflow/Makefile cleanup