### PR TITLE
fix(build-e2e): add openssh-client for private go mod download

### DIFF
--- a/images/Dockerfile.build-e2e
+++ b/images/Dockerfile.build-e2e
@@ -39,8 +39,10 @@ ARG SUBSTRATE_VERSION=v2.225.2
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Base tooling + fonts needed by wkhtmltopdf for legible PDFs.
+# openssh-client: apps fetch private Go modules over git+ssh (GOPRIVATE +
+# `insteadOf git@…`), so `go mod download` needs an ssh binary present.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl gnupg git git-lfs make jq xz-utils \
+      ca-certificates curl gnupg git git-lfs openssh-client make jq xz-utils \
       fontconfig fonts-dejavu fonts-liberation \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What
Adds `openssh-client` to `build-e2e`.

## Why
Apps consuming this image (e.g. their e2e jobs) fetch **private Go modules over git+ssh** — `GOPRIVATE` + `git config insteadOf git@…` — so `go mod download` on a cold cache needs an `ssh` binary present. The image shipped without one (`--no-install-recommends` excludes `openssh-client`), which fails private module resolution in CI. `build-godynamic` already ships ssh (`apk add openssh`); this brings `build-e2e` to parity.

## Test
Rebuilt arm64 locally: `ssh -V` → `OpenSSH_8.9p1`.

Should go into the next tag (**v0.1.1** — v0.1.0 predates `build-e2e`, so the image isn't published yet) alongside #67.