### PR TITLE
fix(build-e2e): bundle pdfserv's full font set (Arial/MS-core) for faithful PDF rendering

### DIFF
--- a/images/Dockerfile.build-e2e
+++ b/images/Dockerfile.build-e2e
@@ -73,6 +73,14 @@ COPY --from=shirotester /opt/app        /usr/local/bin/shirotester
 COPY --from=martin      /ko-app/martin  /usr/local/bin/martin
 COPY --from=pdfserv     /ko-app/pdfserv /usr/local/bin/pdfserv
 
+# Use the EXACT font set from the pdfserv image (DejaVu, Liberation, Droid,
+# FreeFont, and the MS-core fonts incl. Arial). Acre templates render with
+# `font-family: Arial`; without these, wkhtmltopdf falls back to DejaVu and
+# produces visibly different, smaller PDFs than the production pdfserv service.
+# Copying the same files guarantees byte-comparable rendering.
+COPY --from=pdfserv     /usr/share/fonts /usr/share/fonts
+RUN fc-cache -f
+
 # Fail the build if the assembly is wrong. (substratehcp is a go-plugin binary
 # that expects a handshake, so we only check it's present/executable.)
 RUN set -eux; \
@@ -81,4 +89,5 @@ RUN set -eux; \
     martin --help >/dev/null; \
     pdfserv version; \
     wkhtmltopdf --version; \
-    test -x /usr/local/bin/substratehcp
+    test -x /usr/local/bin/substratehcp; \
+    test "$(fc-list | wc -l)" -gt 100   # fonts from pdfserv image present


### PR DESCRIPTION
## What
`COPY --from` the pdfserv image's `/usr/share/fonts` into build-e2e (+ `fc-cache`).

## Why
build-e2e only had DejaVu + Liberation (38 fonts). App templates render with `font-family: Arial`, so wkhtmltopdf fell back to DejaVu — producing **visibly different and smaller PDFs** than the production pdfserv service (which uses the surnet base with Arial/MS-core, Droid, FreeFont = 112 fonts). This broke PDF-size assertions in the e2e and meant native renders didn't match production.

Copying the **exact same font files** guarantees byte-comparable rendering.

## Test
Built arm64 locally: `fc-list` → **150** (was 38), Arial + Times New Roman present. Same sample HTML rendered 14365B before → 28855B with fonts (matches the production pdfserv image). Build now asserts `fc-list > 100`.

For the next tag (**v0.1.2**).