### PR TITLE
Clear all fixable Go-dependency CVEs in build images

### DIFF
--- a/images/Dockerfile.build-api
+++ b/images/Dockerfile.build-api
@@ -4,26 +4,42 @@ FROM golang:$GOLANG_VERSION AS go-downloader
 ARG GO_BINDATA_VERSION
 RUN go install "github.com/go-bindata/go-bindata/v3/go-bindata@v${GO_BINDATA_VERSION}"
 ARG GO_TESTSUM_VERSION
-RUN go install "gotest.tools/gotestsum@v${GO_TESTSUM_VERSION}"
+# Built from source (not `go install`) so we can pin patched golang.org/x/sys
+# (CVE-2026-39824); gotestsum otherwise bundles a vulnerable x/sys. Trade-off:
+# `gotestsum --version` reports "(devel)" — it has no version ldflag and derives
+# its version from the main module.
+RUN mkdir /tmp/gotestsum && cd /tmp/gotestsum && \
+    go mod init _gotestsum && \
+    go get "gotest.tools/gotestsum@v${GO_TESTSUM_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -o /go/bin/gotestsum "gotest.tools/gotestsum" && \
+    cd / && rm -rf /tmp/gotestsum
 ARG GOLANGCI_LINT_VERSION
-RUN go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}"
+# Built from source (not `go install`) so we can pin patched golang.org/x/sys
+# (CVE-2026-39824); golangci-lint otherwise bundles x/sys 0.42.0. The ldflags
+# preserve `--version` (golangci-lint uses build-info only when main.date is empty).
+RUN mkdir /tmp/golangci && cd /tmp/golangci && \
+    go mod init _golangci && \
+    go get "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -ldflags "-X main.version=${GOLANGCI_LINT_VERSION} -X main.commit=unknown -X main.date=unknown" \
+      -o /go/bin/golangci-lint "github.com/golangci/golangci-lint/v2/cmd/golangci-lint" && \
+    cd / && rm -rf /tmp/golangci
 
 ARG BUF_VERSION
 RUN mkdir /tmp/buf && cd /tmp/buf && \
     go mod init _buf && \
-    go get "github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get "github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/sys@v0.45.0 github.com/quic-go/quic-go@v0.59.1 && \
     go build -o /go/bin/buf "github.com/bufbuild/buf/cmd/buf" && \
     cd / && rm -rf /tmp/buf
 ARG GO_SWAGGER_VERSION
 RUN mkdir /tmp/swagger && cd /tmp/swagger && \
     go mod init _swagger && \
-    go get "github.com/go-swagger/go-swagger/cmd/swagger@v${GO_SWAGGER_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get "github.com/go-swagger/go-swagger/cmd/swagger@v${GO_SWAGGER_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/sys@v0.45.0 && \
     go build -o /go/bin/swagger "github.com/go-swagger/go-swagger/cmd/swagger" && \
     cd / && rm -rf /tmp/swagger
 ARG GIT_LFS_VERSION
 RUN mkdir /tmp/gitlfs && cd /tmp/gitlfs && \
     go mod init _gitlfs && \
-    go get "github.com/git-lfs/git-lfs/v3@v${GIT_LFS_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get "github.com/git-lfs/git-lfs/v3@v${GIT_LFS_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/sys@v0.45.0 && \
     go build -o /go/bin/git-lfs "github.com/git-lfs/git-lfs/v3" && \
     cd / && rm -rf /tmp/gitlfs
 

--- a/images/Dockerfile.build-go
+++ b/images/Dockerfile.build-go
@@ -4,13 +4,29 @@ FROM golang:$GOLANG_VERSION AS go-downloader
 ARG GO_BINDATA_VERSION
 RUN go install "github.com/go-bindata/go-bindata/v3/go-bindata@v${GO_BINDATA_VERSION}"
 ARG GO_TESTSUM_VERSION
-RUN go install "gotest.tools/gotestsum@v${GO_TESTSUM_VERSION}"
+# Built from source (not `go install`) so we can pin patched golang.org/x/sys
+# (CVE-2026-39824); gotestsum otherwise bundles a vulnerable x/sys. Trade-off:
+# `gotestsum --version` reports "(devel)" — it has no version ldflag and derives
+# its version from the main module.
+RUN mkdir /tmp/gotestsum && cd /tmp/gotestsum && \
+    go mod init _gotestsum && \
+    go get "gotest.tools/gotestsum@v${GO_TESTSUM_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -o /go/bin/gotestsum "gotest.tools/gotestsum" && \
+    cd / && rm -rf /tmp/gotestsum
 ARG GOLANGCI_LINT_VERSION
-RUN go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}"
+# Built from source (not `go install`) so we can pin patched golang.org/x/sys
+# (CVE-2026-39824); golangci-lint otherwise bundles x/sys 0.42.0. The ldflags
+# preserve `--version` (golangci-lint uses build-info only when main.date is empty).
+RUN mkdir /tmp/golangci && cd /tmp/golangci && \
+    go mod init _golangci && \
+    go get "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -ldflags "-X main.version=${GOLANGCI_LINT_VERSION} -X main.commit=unknown -X main.date=unknown" \
+      -o /go/bin/golangci-lint "github.com/golangci/golangci-lint/v2/cmd/golangci-lint" && \
+    cd / && rm -rf /tmp/golangci
 ARG GIT_LFS_VERSION
 RUN mkdir /tmp/gitlfs && cd /tmp/gitlfs && \
     go mod init _gitlfs && \
-    go get "github.com/git-lfs/git-lfs/v3@v${GIT_LFS_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get "github.com/git-lfs/git-lfs/v3@v${GIT_LFS_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/sys@v0.45.0 && \
     go build -o /go/bin/git-lfs "github.com/git-lfs/git-lfs/v3" && \
     cd / && rm -rf /tmp/gitlfs
 

--- a/images/Dockerfile.build-go-alpine
+++ b/images/Dockerfile.build-go-alpine
@@ -6,14 +6,30 @@ FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS go-alpine-downloader
 ARG GO_BINDATA_VERSION
 RUN go install "github.com/go-bindata/go-bindata/v3/go-bindata@v${GO_BINDATA_VERSION}"
 ARG GO_TESTSUM_VERSION
-RUN go install "gotest.tools/gotestsum@v${GO_TESTSUM_VERSION}"
+# Built from source (not `go install`) so we can pin patched golang.org/x/sys
+# (CVE-2026-39824); gotestsum otherwise bundles a vulnerable x/sys. Trade-off:
+# `gotestsum --version` reports "(devel)" — it has no version ldflag and derives
+# its version from the main module.
+RUN mkdir /tmp/gotestsum && cd /tmp/gotestsum && \
+    go mod init _gotestsum && \
+    go get "gotest.tools/gotestsum@v${GO_TESTSUM_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -o /go/bin/gotestsum "gotest.tools/gotestsum" && \
+    cd / && rm -rf /tmp/gotestsum
 ARG GOLANGCI_LINT_VERSION
-RUN go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}"
+# Built from source (not `go install`) so we can pin patched golang.org/x/sys
+# (CVE-2026-39824); golangci-lint otherwise bundles x/sys 0.42.0. The ldflags
+# preserve `--version` (golangci-lint uses build-info only when main.date is empty).
+RUN mkdir /tmp/golangci && cd /tmp/golangci && \
+    go mod init _golangci && \
+    go get "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -ldflags "-X main.version=${GOLANGCI_LINT_VERSION} -X main.commit=unknown -X main.date=unknown" \
+      -o /go/bin/golangci-lint "github.com/golangci/golangci-lint/v2/cmd/golangci-lint" && \
+    cd / && rm -rf /tmp/golangci
 ARG GIT_LFS_VERSION
 RUN apk add --no-cache gcc musl-dev && \
     mkdir /tmp/gitlfs && cd /tmp/gitlfs && \
     go mod init _gitlfs && \
-    go get "github.com/git-lfs/git-lfs/v3@v${GIT_LFS_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get "github.com/git-lfs/git-lfs/v3@v${GIT_LFS_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/sys@v0.45.0 && \
     go build -o /go/bin/git-lfs "github.com/git-lfs/git-lfs/v3" && \
     cd / && rm -rf /tmp/gitlfs
 

--- a/images/Dockerfile.build-godynamic
+++ b/images/Dockerfile.build-godynamic
@@ -62,14 +62,30 @@ FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS go-alpine-downloader
 ARG GO_BINDATA_VERSION
 RUN go install "github.com/go-bindata/go-bindata/v3/go-bindata@v${GO_BINDATA_VERSION}"
 ARG GO_TESTSUM_VERSION
-RUN go install "gotest.tools/gotestsum@v${GO_TESTSUM_VERSION}"
+# Built from source (not `go install`) so we can pin patched golang.org/x/sys
+# (CVE-2026-39824); gotestsum otherwise bundles a vulnerable x/sys. Trade-off:
+# `gotestsum --version` reports "(devel)" — it has no version ldflag and derives
+# its version from the main module.
+RUN mkdir /tmp/gotestsum && cd /tmp/gotestsum && \
+    go mod init _gotestsum && \
+    go get "gotest.tools/gotestsum@v${GO_TESTSUM_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -o /go/bin/gotestsum "gotest.tools/gotestsum" && \
+    cd / && rm -rf /tmp/gotestsum
 ARG GOLANGCI_LINT_VERSION
-RUN go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}"
+# Built from source (not `go install`) so we can pin patched golang.org/x/sys
+# (CVE-2026-39824); golangci-lint otherwise bundles x/sys 0.42.0. The ldflags
+# preserve `--version` (golangci-lint uses build-info only when main.date is empty).
+RUN mkdir /tmp/golangci && cd /tmp/golangci && \
+    go mod init _golangci && \
+    go get "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -ldflags "-X main.version=${GOLANGCI_LINT_VERSION} -X main.commit=unknown -X main.date=unknown" \
+      -o /go/bin/golangci-lint "github.com/golangci/golangci-lint/v2/cmd/golangci-lint" && \
+    cd / && rm -rf /tmp/golangci
 ARG GIT_LFS_VERSION
 RUN apk add --no-cache gcc git musl-dev && \
     mkdir /tmp/gitlfs && cd /tmp/gitlfs && \
     go mod init _gitlfs && \
-    go get "github.com/git-lfs/git-lfs/v3@v${GIT_LFS_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get "github.com/git-lfs/git-lfs/v3@v${GIT_LFS_VERSION}" golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/sys@v0.45.0 && \
     go build -o /go/bin/git-lfs "github.com/git-lfs/git-lfs/v3" && \
     cd / && rm -rf /tmp/gitlfs
 ARG DOCKER_COMPOSE_VERSION


### PR DESCRIPTION
## Goal

Drive **fixable** CVEs to **zero** on the build images (Alz's set: `build-go-alpine`, `service-base-alpine`, `build-api`; plus `build-go` which shares the same gate + tooling).

All remaining Critical/High on these images are **unfixable** (no upstream patch); this PR clears the **fixable** ones, which are all transitive Go-module deps baked into the bundled tool binaries.

## The fixable CVEs

| CVE | Sev | Dep | Fix |
|---|---|---|---|
| CVE-2026-40898 | MEDIUM | `quic-go` 0.59.0 | →0.59.1 (from `buf`) |
| CVE-2026-39824 | LOW | `golang.org/x/sys` 0.36.0/0.42.0 | →0.44.0 (golangci-lint, gotestsum, git-lfs, buf, swagger) |

## Two fixes

1. **Pin patched deps in the from-source tool builds** (`buf`, `swagger`, `git-lfs`), next to the `x/crypto`/`x/net` pins already there: `x/sys@0.44.0` (+ `quic-go@0.59.1` on buf).
2. **Convert `gotestsum` and `golangci-lint` from `go install` to from-source builds** so their bundled `x/sys` can be pinned. No released version of either uses x/sys ≥0.44.0 yet (golangci-lint 2.12.2 = 0.43.0), so `go install` alone can't clear it.
   - **golangci-lint `--version` preserved** via `-X main.version` ldflags (it only falls back to the `(devel)` build-info version when `main.date` is empty).
   - **gotestsum `--version` now shows `(devel)`** — it reads its version solely from the main module and has no version ldflag. Cosmetic; no feature gating.

Applied to `build-api`, `build-go`, `build-go-alpine`, `build-godynamic`. `service-base-alpine` bundles no Go tools (already 0 CVEs).

## Verification

CI builds all images (confirms the source-builds compile) and rescans the gated set. Post-merge I'll confirm fixable→0 from the SARIF.