### PR TITLE
Add supply-chain attestations + non-root default user (Docker Scout)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,3 +77,78 @@ jobs:
           write-comment: false
           dockerhub-user: ${{ env.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ env.DOCKERHUB_TOKEN }}
+
+  # Gate the release on supply-chain attestations actually being present on the
+  # PUBLISHED multi-arch image. The Makefile attaches SBOM + provenance during
+  # the per-arch build, but `make push-manifests` (buildx imagetools create)
+  # re-assembles the index and is the step that can silently DROP the
+  # attestation manifests. This job is the automated replacement for inspecting
+  # the image by hand: it fails the release if any platform is missing either
+  # predicate, so a regression in the combine step can never ship unnoticed.
+  verify-attestations:
+    name: Verify attestations (${{ matrix.image }})
+    runs-on: ubuntu-22.04
+    needs:
+      - push-manifests
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - build-api
+          - build-go
+          - build-go-alpine
+          - build-godynamic
+          - build-e2e
+          - build-java
+          - build-js
+          - build-swaggercodegen
+          - nginx-frontend
+          - service-base-alpine
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Configure DockerHub
+        uses: ./.github/actions/configure-dockerhub
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+      - name: Verify SBOM + provenance attestations on published image
+        env:
+          IMG: luthersystems/${{ matrix.image }}:${{ github.ref_name }}
+          REPO: luthersystems/${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          echo "Inspecting $IMG"
+          RAW=$(docker buildx imagetools inspect "$IMG" --raw)
+
+          # Count real platform images vs sibling attestation manifests. buildx
+          # emits one attestation manifest per platform, tagged in the index
+          # with annotation vnd.docker.reference.type=attestation-manifest.
+          PLATS=$(echo "$RAW" | jq '[.manifests[]
+            | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+            | select((.platform.os // "") != "unknown")] | length')
+          ATTS=$(echo "$RAW" | jq '[.manifests[]
+            | select((.annotations["vnd.docker.reference.type"] // "") == "attestation-manifest")] | length')
+          echo "platform images=$PLATS  attestation manifests=$ATTS"
+
+          if [ "$ATTS" -lt 1 ] || [ "$ATTS" -ne "$PLATS" ]; then
+            echo "::error::$IMG is missing attestation manifests (platforms=$PLATS, attestations=$ATTS). 'buildx imagetools create' likely dropped them — check images/Makefile push-manifests."
+            echo "$RAW" | jq .
+            exit 1
+          fi
+
+          # For each attestation manifest, confirm BOTH predicate types are
+          # present (provenance + SBOM), not just one. Uses --raw so it does not
+          # depend on the runner's buildx supporting the .SBOM/.Provenance
+          # format fields.
+          MISSING=0
+          for DGST in $(echo "$RAW" | jq -r '.manifests[]
+              | select((.annotations["vnd.docker.reference.type"] // "") == "attestation-manifest")
+              | .digest'); do
+            AM=$(docker buildx imagetools inspect "${REPO}@${DGST}" --raw)
+            PTYPES=$(echo "$AM" | jq -r '.layers[].annotations["in-toto.io/predicate-type"] // empty')
+            echo "  $DGST predicate-types: $(echo "$PTYPES" | paste -sd, -)"
+            echo "$PTYPES" | grep -q 'slsa.dev/provenance' || { echo "::error::$IMG attestation $DGST missing provenance predicate"; MISSING=1; }
+            echo "$PTYPES" | grep -qE 'spdx.dev/Document|cyclonedx' || { echo "::error::$IMG attestation $DGST missing SBOM predicate"; MISSING=1; }
+          done
+          [ "$MISSING" -eq 0 ] || exit 1
+          echo "✅ $IMG carries SBOM + provenance for all $PLATS platform(s)"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,44 @@ make echo:VERSION
 Github actions is configured to push releaes on version tag pushes. Create a
 release for the new version via the github UI and it will automatically kick
 off the release pipeline.
+
+## Image security policies
+
+The published images are scanned against Docker Scout policies. Two policy
+requirements affect how downstream repos consume these images:
+
+### Supply-chain attestations
+
+Every published image carries SBOM + SLSA provenance attestations. These are
+attached during the per-arch `buildx build` (gated to tag/push builds in
+`images/Makefile`) and the `verify-attestations` job in `publish.yml` fails the
+release if any platform is missing either predicate. No action is required
+downstream — this is purely a property of the published image.
+
+### Non-root default user (downstream coordination required)
+
+To satisfy Docker Scout's "no default non-root user" policy, the build images
+default to a non-root `build` user (uid 1000):
+
+- `service-base-alpine` runs as `nobody` (the prod runtime image).
+- `build-api` defaults to `build`; its consumers already run it with
+  `-u $(id -u):$(id -g)`, which overrides the default and keeps working.
+- `build-go-alpine` defaults to `build`.
+
+**`build-go-alpine` is also used as a `FROM` base in downstream multi-stage
+builds** (e.g. `ui-core/Dockerfile-go`, and any repo using the shared
+`common.go.mk` + `Dockerfile-go` pattern). Those build stages inherit the
+non-root `USER`, but they write **root-owned BuildKit cache mounts**
+(`--mount=type=cache,target=/go/pkg/mod` for `go mod download`,
+`/root/.cache/go-build`) and `COPY` root-owned sources, so they will fail with
+permission-denied unless the build stage re-asserts root:
+
+```dockerfile
+FROM $BUILD_IMAGE AS build
+USER root          # required: build stage needs to write the root-owned cache mounts
+```
+
+The prod stage (`FROM service-base-alpine`) is unaffected and still runs as
+`nobody`. **Land this one-line change in every consumer before bumping the
+`BUILDENV_TAG` those repos pin to a release carrying the non-root default**, or
+their builds will break.

--- a/images/Dockerfile.build-api
+++ b/images/Dockerfile.build-api
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.26.2
+ARG GOLANG_VERSION=1.26.4
 FROM golang:$GOLANG_VERSION AS go-downloader
 
 ARG GO_BINDATA_VERSION
@@ -60,4 +60,15 @@ COPY --from=go-downloader /go/bin/swagger /go/bin/swagger
 COPY --from=go-downloader /go/bin/git-lfs /go/bin/git-lfs
 
 COPY build-api.mk /opt/Dockerfile.api.mk
+
+# Default to a non-root user (Docker Scout "no default non-root user" policy).
+# This image is consumed via `docker run`, and its workspace-mounting consumers
+# already pass `-u $(id -u):$(id -g)` (e.g. ui-core api/Makefile), which
+# overrides this default and still works — the tools in /go/bin are
+# world-executable. HOME points at a writable dir so any tooling that touches
+# $HOME works even when no `-u` is supplied. The official golang image ships
+# GOPATH (/go) mode 1777, so module/cache writes succeed for a non-root uid.
+RUN useradd --create-home --uid 1000 --user-group build
+ENV HOME=/home/build
+USER build
 ENTRYPOINT ["tini", "--", "sh", "-c", "make -f /opt/Dockerfile.api.mk -C $PWD build"]

--- a/images/Dockerfile.build-go-alpine
+++ b/images/Dockerfile.build-go-alpine
@@ -69,4 +69,24 @@ RUN git config --system url."git@github.com:luthersystems/license.git".insteadOf
   ssh-keyscan -t Ed25519 -H github.com | tee -a /etc/ssh/ssh_known_hosts
 
 ENV GOCACHE=/tmp
+
+# Default to a non-root user (Docker Scout "no default non-root user" policy).
+# All privileged setup above (apk add, jq@edge, git config --system,
+# ssh-keyscan into /etc/ssh) runs as root before this line. The official
+# golang image ships GOPATH (/go) mode 1777 and GOCACHE=/tmp is 1777, so Go
+# module/build-cache writes succeed for a non-root uid. HOME points at a
+# writable dir for tooling that reads/writes $HOME.
+#
+# IMPORTANT — downstream coordination required: this image is also consumed as
+# a `FROM` base in downstream multi-stage builds (e.g. ui-core Dockerfile-go,
+# and any repo using the shared common.go.mk pattern). Those build stages
+# inherit this USER, so a consumer that needs root at build time — notably one
+# writing a BuildKit cache mount at /go/pkg/mod (`go mod download`) or running
+# `apk add` — MUST declare `USER root` at the top of its build stage (and/or
+# set uid=/gid= on its cache mounts). Land those downstream changes before
+# bumping the buildenv tag those repos pin, or their builds will fail on
+# permission-denied writing the root-owned cache mount.
+RUN addgroup -g 1000 build && adduser -D -u 1000 -G build -h /home/build build
+ENV HOME=/home/build
+USER build
 ENTRYPOINT ["tini", "--"]

--- a/images/Makefile
+++ b/images/Makefile
@@ -24,6 +24,18 @@ PLATFORMS=linux/amd64,linux/arm64
 # GitHub Actions layer caching (--cache-from/--cache-to type=gha).
 BUILDX_CACHE_FLAGS ?=
 
+# Supply-chain attestations (SBOM + SLSA provenance, mode=max). These satisfy
+# Docker Scout's "supply chain attestation(s)" policy. Attestations only attach
+# to images exported to a registry; the local docker exporter (--load) rejects
+# them, so gate on GIT_TAG exactly like --push above (a local `make ... --load`
+# build stays attestation-free and keeps working). On the per-arch publish
+# build these attach to luthersystems/<img>:<ver>-<arch>; `make push-manifests`
+# (buildx imagetools create) carries the attestation manifests into the
+# combined multi-arch index. Verify post-publish with:
+#   docker buildx imagetools inspect luthersystems/<img>:<ver> --format '{{json .}}'
+# and confirm application/vnd.in-toto+json manifests exist per platform.
+DOCKER_ATTEST_OPTS=$(if $(GIT_TAG),--provenance=mode=max --sbom=true,)
+
 # do *NOT* delete intermediate artifacts!
 .SECONDARY:
 
@@ -48,7 +60,7 @@ clean:
 $(call IMAGE_DUMMY,luthersystems/%): Dockerfile.% Makefile ${COMMON_MAKEFILE} ${CONFIG_MAKEFILE} $(call DUMMY_TARGET,deps,luthersystems/%)
 	@echo "Building image $*"
 	${DOCKER} buildx inspect --bootstrap
-	${DOCKER} buildx build ${DOCKER_BUILDX_OPTS} ${BUILDX_CACHE_FLAGS} \
+	${DOCKER} buildx build ${DOCKER_BUILDX_OPTS} ${DOCKER_ATTEST_OPTS} ${BUILDX_CACHE_FLAGS} \
 		--platform ${PLATFORMS} \
 		--progress plain \
 		--build-arg GOLANGCI_LINT_VERSION=${GOLANGCI_LINT_VERSION} \


### PR DESCRIPTION
Addresses two Docker Scout policy findings Allianz raised on the build-go-alpine, service-base-alpine, and build-api images.

## Supply-chain attestations (SBOM + provenance)

- Add `DOCKER_ATTEST_OPTS=--provenance=mode=max --sbom=true` to `images/Makefile`, applied to every published image. Gated on `GIT_TAG` (same as `--push`) because attestations only attach to registry-exported images; the local `--load` exporter rejects them, so `make ... --load` builds are unchanged.
- New `verify-attestations` job in `publish.yml` runs after `push-manifests` and fails the release if any platform of any published image is missing its SBOM or provenance predicate. This automates the otherwise-manual `docker buildx imagetools inspect` check and specifically guards the `buildx imagetools create` combine step, which is where attestations can be silently dropped. Verification uses `--raw` so it does not depend on the runner's buildx supporting the `.SBOM`/`.Provenance` format fields.

## Non-root default user

- `build-api`: add a non-root `build` user + writable `HOME`. Safe because its workspace-mounting consumers already pass `-u $(id -u):$(id -g)` (ui-core `api/Makefile`), which overrides the default and keeps working.
- `build-go-alpine`: add a non-root `build` user + writable `HOME`. GOPATH (`/go`) ships mode 1777 and `GOCACHE=/tmp` is 1777, so the image is fully functional non-root (verified: module-cache write, build-cache write, `go` run).
- `service-base-alpine`: already runs as `nobody` — no change.
- Also bump `build-api`'s stale default `GOLANG_VERSION` ARG 1.26.2 -> 1.26.4 to match `common.config.mk`.

## Downstream coordination required

`build-go-alpine` is consumed as a `FROM` base in downstream multi-stage builds (e.g. `ui-core/Dockerfile-go`, and any repo using the shared `common.go.mk` pattern). Those build stages inherit the non-root `USER` and write root-owned BuildKit cache mounts (`/go/pkg/mod`, `/root/.cache/go-build`), so each consumer must add a one-line `USER root` to its build stage before bumping `BUILDENV_TAG` to a release carrying this change. The prod stage (`FROM service-base-alpine`) is unaffected and still runs as `nobody`.

```dockerfile
FROM $BUILD_IMAGE AS build
USER root          # required: build stage writes root-owned cache mounts
```

This requirement is documented in the README (per request) rather than changed in ui-core here.

## Test plan

- Verified locally: Makefile attestation gating (off for `--load`, on for tag builds), both Dockerfiles parse clean via `buildx --check`, a non-root uid-1000 user can write the module/build caches and run `go` on the alpine base, `publish.yml` is valid YAML, and the attestation jq filters work against a sample OCI index.
- CI on this PR builds every image and runs the Scout CVE gate.
- Note: the `verify-attestations` job only runs on tag pushes (it needs a published image), so its first live exercise is the next release; its logic is validated locally here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019FkGHrbwJf8gbQwCt1j1aE)_