### PR TITLE
ci: enforce and maintain grade-A Docker Scout bill of health

### DIFF
--- a/.claude/skills/scout-fix/SKILL.md
+++ b/.claude/skills/scout-fix/SKILL.md
@@ -40,8 +40,8 @@ findings; `cves` tells you CVE findings.
 | Fixable CVE in an **OS package** (apt/apk) | upgrade OS packages (escape hatch: pull one pkg from edge) | **A** |
 | CVE that only the **base image** carries | bump the central base version | **B** |
 | Fixable CVE in a **bundled Go tool** (golangci-lint, buf, swagger, git-lfs, gotestsum…) | from-source build + pin the patched transitive dep | **C** |
-| Policy: **default non-root user** | add a non-root `USER` (+ downstream check) | **D** |
-| Policy: **supply-chain attestations** | Makefile attestation opts (release-only) | **E** |
+| Policy: **default non-root user** | already satisfied; only when a NEW image joins the set | **D** |
+| Policy: **supply-chain attestations** | already wired in Makefile/CI; not a Dockerfile fix | **E** |
 
 ---
 
@@ -140,62 +140,47 @@ Rules learned the hard way (#77):
 
 ---
 
-## D — Policy: default non-root user
+## D — Policy: default non-root user (already satisfied — rarely a fix step)
 
-Scout's "default non-root user" policy (5 pts) wants a non-root default `USER`.
-Add a uid-1000 user **after all privileged setup**, point `HOME` at a writable
-dir, then `USER` it (#78).
+The three required images are **already non-root**: `build-api` and
+`build-go-alpine` default to user `build` (uid 1000), `service-base-alpine` to
+`nobody` (#78). A routine CVE fix never touches this; the PR gate's non-root
+assertion just stops a regression. **Don't re-add what's already there.**
 
-Debian (build-api):
-```dockerfile
-RUN useradd --create-home --uid 1000 --user-group build
-ENV HOME=/home/build
-USER build
-```
-Alpine (build-go-alpine):
-```dockerfile
-RUN addgroup -g 1000 build && adduser -D -u 1000 -G build -h /home/build build
-ENV HOME=/home/build
-USER build
-```
+You apply this pattern only when a **brand-new image joins the required set**.
+Then add a uid-1000 user **after all privileged setup** (`apk add`/`apt`, `git
+config --system`, `ssh-keyscan`, root-owned `COPY`s), give it a writable `HOME`,
+and `USER` it — Debian: `useradd --create-home --uid 1000 --user-group build`;
+Alpine: `addgroup -g 1000 build && adduser -D -u 1000 -G build -h /home/build
+build`. Go caches stay writable because `/go` is mode 1777 and `GOCACHE=/tmp`
+is 1777.
 
-Checks before you commit:
-- **Placement:** `USER` must come *after* every `apk add` / `apt`, `git config
-  --system`, `ssh-keyscan`, and `COPY` of root-owned files.
-- **Writability:** Go needs writable GOPATH/cache. The official golang image
-  ships `/go` mode 1777 and these images set `GOCACHE=/tmp` (1777), so non-root
-  module/build-cache writes work. Verify: run the image and write the caches.
-- **⚠️ Downstream `FROM`-base coordination (the #78 footgun).** `build-go-alpine`
-  is used as a `FROM` base in downstream multi-stage builds (ui-core
-  `Dockerfile-go`, anything on the shared `common.go.mk` pattern). Those build
-  stages **inherit this `USER`** and then fail writing the root-owned BuildKit
-  cache mount (`/go/pkg/mod`) or running `apk add`. Each consumer must add
-  `USER root` to its build stage first. **Land those downstream changes (and
-  document the requirement in README) BEFORE releasing a tag that carries this.**
-  The prod stage (`FROM service-base-alpine`) is unaffected — it stays `nobody`.
+⚠️ **The downstream coordination is a RELEASE precondition, not a CVE-fix step.**
+If the new image is a `FROM` base for downstream multi-stage builds (as
+`build-go-alpine` is for ui-core `Dockerfile-go` and anything on the shared
+`common.go.mk` pattern), each consumer's build stage **inherits the `USER`** and
+fails writing the root-owned `/go/pkg/mod` cache mount — so every consumer must
+add `USER root` to its build stage *before* it bumps `BUILDENV_TAG` to a release
+carrying the non-root default. This is owned by whoever cuts the release (see the
+README non-root section), not by your finding fix. The prod stage (`FROM
+service-base-alpine`) is unaffected — it stays `nobody`.
 
 ---
 
-## E — Policy: supply-chain attestations
+## E — Policy: supply-chain attestations (already wired — not a Dockerfile fix)
 
-SBOM + SLSA provenance attestations (15 pts) are produced by the Makefile and
-**only attach on push to a registry** — the local `--load` exporter rejects
-them. So this is a *release-time* property, not something you can satisfy on a PR
-build (#78). The wiring already exists:
+SBOM + SLSA provenance (15 pts) are **already produced** by the Makefile
+(`DOCKER_ATTEST_OPTS=$(if $(GIT_TAG),--provenance=mode=max --sbom=true,)`, gated
+on `GIT_TAG`) and only attach on push — the `--load` exporter rejects them. So
+you can't satisfy this on a PR build, and you **never** add
+`--sbom`/`--provenance` to a `--load` build (it breaks the local build). There's
+no Dockerfile edit here (#78).
 
-```makefile
-DOCKER_ATTEST_OPTS=$(if $(GIT_TAG),--provenance=mode=max --sbom=true,)
-```
-
-If attestations are missing on a published image, the bug is in the
-**`push-manifests`** step (buildx `imagetools create` can drop attestation
-manifests when recombining the multi-arch index), not in a Dockerfile. The
-`verify-attestations` job in `publish.yml` guards this. Verify by hand with:
-```bash
-docker buildx imagetools inspect luthersystems/<img>:<ver> --raw   # expect per-platform in-toto manifests
-```
-Do **not** try to add `--sbom`/`--provenance` to `--load` builds; that breaks the
-local build for everyone.
+If the attestations policy fails on a *published* image, it's a `push-manifests`
+regression (buildx `imagetools create` dropping attestation manifests), not a
+finding you fix in `images/` — the `verify-attestations` job in `publish.yml`
+already guards it. Inspect with `docker buildx imagetools inspect
+luthersystems/<img>:<ver> --raw` (expect per-platform in-toto manifests).
 
 ---
 

--- a/.claude/skills/scout-fix/SKILL.md
+++ b/.claude/skills/scout-fix/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: scout-fix
+description: "Resolve a Docker Scout finding (a CVE or a failed policy) on a build image and restore its grade-A bill of health. Use when a CI Scout gate is red, the weekly scout-drift issue fires, or a customer (e.g. Allianz) reports a Scout policy finding. Captures how #71/#72, #74, #76, #77, #78 were fixed. Examples: 'fix the fixable HIGH CVE in build-go-alpine', 'service-base-alpine dropped below grade A', 'clear the x/sys CVE in the go tools'."
+---
+
+# Fix a Docker Scout finding on a build image
+
+This is the playbook that produced PRs #71/#72 → #78 (build-api, build-go-alpine,
+service-base-alpine to a clean grade-A Docker Scout health score). Follow it
+whenever a Scout finding needs clearing. **Most fixes are a version bump in one
+place; the hard ones are transitive Go pins — both patterns are below.**
+
+> Background on the grade and where the gates live: README "Image security
+> policies" and [CLAUDE.md](../../../CLAUDE.md). The required set is
+> `.github/scout-required-images.json`.
+
+## Step 0 — Reproduce and classify (always do this first)
+
+Build the image locally and look at the real finding. Never fix blind from a CI
+log alone.
+
+```bash
+cd images
+img=build-go-alpine                       # the affected image
+make PLATFORMS=linux/amd64 DOCKER_BUILDX_OPTS=--load "$img"
+ref="local://luthersystems/${img}:$(git rev-parse HEAD)"
+
+docker scout quickview  "$ref"            # C/H/M/L counts + which policies pass
+docker scout cves       "$ref" --only-fixed --only-severities critical,high   # the PR hard gate
+docker scout cves       "$ref" --details --only-fixed   # package + fixed-in version per CVE
+docker scout recommendations "$ref"       # base-image freshness suggestions
+```
+
+Read the output and classify the finding into exactly one of the five rows
+below, then jump to that section. A `quickview` policy line tells you policy
+findings; `cves` tells you CVE findings.
+
+| Finding | Fix pattern | Section |
+|---|---|---|
+| Fixable CVE in an **OS package** (apt/apk) | upgrade OS packages (escape hatch: pull one pkg from edge) | **A** |
+| CVE that only the **base image** carries | bump the central base version | **B** |
+| Fixable CVE in a **bundled Go tool** (golangci-lint, buf, swagger, git-lfs, gotestsum…) | from-source build + pin the patched transitive dep | **C** |
+| Policy: **default non-root user** | add a non-root `USER` (+ downstream check) | **D** |
+| Policy: **supply-chain attestations** | Makefile attestation opts (release-only) | **E** |
+
+---
+
+## A — OS package CVE (apt / apk)
+
+The fix is to pull patched OS packages at build time. Consolidate into the
+existing setup `RUN` so package lists are valid, and clean the cache.
+
+**Debian/Ubuntu base** (build-api, build-go, build-e2e) — `apt`:
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+      <packages> && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+**Alpine base** (build-go-alpine, build-godynamic, service-base-alpine) — `apk`:
+```dockerfile
+RUN apk update && apk upgrade --no-cache && apk add --no-cache <packages>
+```
+
+**Escape hatch — fix only in alpine `edge`** (real example: jq 1.8.1-r0 carried
+fixable HIGH CVE-2026-32316 / CVE-2026-40164; the fix 1.8.2-r0 shipped in edge
+before 3.24 stable, #76). Pull *only that package* from a tagged edge repo and
+leave a revert note:
+```dockerfile
+# jq: patched jq (>=1.8.2-r0) is only in alpine edge; 3.24 stable still ships
+# vulnerable 1.8.1-r0. Pull jq (only) from edge until backported, then drop this.
+RUN echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+  apk add --no-cache jq@edge
+```
+The `@edge` tag scopes edge to that one package; everything else stays stable.
+**Record the revert condition in a comment** so it's removed once stable catches up.
+
+---
+
+## B — Base image CVE
+
+If the CVE is in the base layer itself, bump the **central** version in
+`common.config.mk`, then the matching `ARG <X>=<default>` fallbacks in the
+Dockerfiles that declare them. Confirm the new base actually clears it before
+committing (real example #76: alpine 3.23 → 3.24 cleared a lingering medium):
+
+```bash
+docker scout quickview alpine:3.24
+docker scout quickview golang:1.26.4-alpine3.24
+```
+
+`common.config.mk` is the source of truth; CI always builds with it. Update the
+`ARG` defaults too so a bare local `docker build` doesn't regress. No apk/apt
+package is version-pinned, so minor base bumps resolve cleanly.
+
+---
+
+## C — Bundled Go tool CVE (the from-source pin pattern)
+
+The gated images build CLI tools (golangci-lint, buf, go-swagger, git-lfs,
+gotestsum, go-bindata) from Go modules. A released tool often bundles a
+**vulnerable transitive dep** (commonly `golang.org/x/sys`, `x/crypto`, `x/net`,
+or `quic-go`). The fix is to build the tool **from source in a throwaway module**
+and `go get` a **patched** version of the transitive dep before building.
+
+Pattern (mirror the existing blocks in `Dockerfile.build-api` /
+`Dockerfile.build-go-alpine`):
+```dockerfile
+ARG GOLANGCI_LINT_VERSION
+RUN mkdir /tmp/golangci && cd /tmp/golangci && \
+    go mod init _golangci && \
+    go get "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}" golang.org/x/sys@v0.45.0 && \
+    go build -ldflags "-X main.version=${GOLANGCI_LINT_VERSION} -X main.commit=unknown -X main.date=unknown" \
+      -o /go/bin/golangci-lint "github.com/golangci/golangci-lint/v2/cmd/golangci-lint" && \
+    cd / && rm -rf /tmp/golangci
+```
+
+Rules learned the hard way (#77):
+
+1. **If the tool is currently `go install`-ed, convert it to from-source** so you
+   can pin the transitive. `go install` gives you no control over transitive deps.
+2. **Pick the pin version to avoid a downgrade conflict.** Pin to the *highest*
+   patched version any sibling dep already requires, not the bare "fixed-in".
+   Example: pin `x/sys@v0.45.0` (not the 0.44.0 "fixed-in") because
+   `x/crypto@v0.52.0` and `x/net@v0.55.0` already require 0.45.0 — pinning lower
+   fails to build. After editing, the explicit pin is often defensive (the tool
+   may already get the patched dep transitively); keep it explicit anyway so the
+   gate can't regress silently.
+3. **Preserve `--version` where it matters.** golangci-lint reads build-info only
+   when `main.date` is empty, so the `-X main.version=…` ldflags keep `--version`
+   correct. gotestsum has no version ldflag and derives its version from the main
+   module, so from-source it reports `(devel)` — cosmetic, leave a comment.
+4. **Apply across every gated image that ships the tool** (build-api, build-go,
+   build-go-alpine, build-godynamic). `service-base-alpine` bundles no Go tools.
+5. **Leave a comment with the CVE id** next to the pin (e.g. `# CVE-2026-39824`,
+   `quic-go@v0.59.1 # CVE-2026-40898`) so the next reader knows why it's pinned
+   and when it can be dropped.
+
+---
+
+## D — Policy: default non-root user
+
+Scout's "default non-root user" policy (5 pts) wants a non-root default `USER`.
+Add a uid-1000 user **after all privileged setup**, point `HOME` at a writable
+dir, then `USER` it (#78).
+
+Debian (build-api):
+```dockerfile
+RUN useradd --create-home --uid 1000 --user-group build
+ENV HOME=/home/build
+USER build
+```
+Alpine (build-go-alpine):
+```dockerfile
+RUN addgroup -g 1000 build && adduser -D -u 1000 -G build -h /home/build build
+ENV HOME=/home/build
+USER build
+```
+
+Checks before you commit:
+- **Placement:** `USER` must come *after* every `apk add` / `apt`, `git config
+  --system`, `ssh-keyscan`, and `COPY` of root-owned files.
+- **Writability:** Go needs writable GOPATH/cache. The official golang image
+  ships `/go` mode 1777 and these images set `GOCACHE=/tmp` (1777), so non-root
+  module/build-cache writes work. Verify: run the image and write the caches.
+- **⚠️ Downstream `FROM`-base coordination (the #78 footgun).** `build-go-alpine`
+  is used as a `FROM` base in downstream multi-stage builds (ui-core
+  `Dockerfile-go`, anything on the shared `common.go.mk` pattern). Those build
+  stages **inherit this `USER`** and then fail writing the root-owned BuildKit
+  cache mount (`/go/pkg/mod`) or running `apk add`. Each consumer must add
+  `USER root` to its build stage first. **Land those downstream changes (and
+  document the requirement in README) BEFORE releasing a tag that carries this.**
+  The prod stage (`FROM service-base-alpine`) is unaffected — it stays `nobody`.
+
+---
+
+## E — Policy: supply-chain attestations
+
+SBOM + SLSA provenance attestations (15 pts) are produced by the Makefile and
+**only attach on push to a registry** — the local `--load` exporter rejects
+them. So this is a *release-time* property, not something you can satisfy on a PR
+build (#78). The wiring already exists:
+
+```makefile
+DOCKER_ATTEST_OPTS=$(if $(GIT_TAG),--provenance=mode=max --sbom=true,)
+```
+
+If attestations are missing on a published image, the bug is in the
+**`push-manifests`** step (buildx `imagetools create` can drop attestation
+manifests when recombining the multi-arch index), not in a Dockerfile. The
+`verify-attestations` job in `publish.yml` guards this. Verify by hand with:
+```bash
+docker buildx imagetools inspect luthersystems/<img>:<ver> --raw   # expect per-platform in-toto manifests
+```
+Do **not** try to add `--sbom`/`--provenance` to `--load` builds; that breaks the
+local build for everyone.
+
+---
+
+## Step N — Verify, then PR
+
+1. Rebuild every image you touched and run **`/verify-scout`** — the grade-A
+   images must show **0 fixable CRITICAL/HIGH** and a non-root `USER`.
+2. If you bumped `common.config.mk`, rebuild **every** image that consumes that
+   ARG (a Go bump touches all Go images), not just the one that flagged.
+3. Open a PR. The `cve-scan` gate re-runs your check; the release `scout-policy`
+   gate enforces the true grade on the pushed image. A human cuts the tag.
+
+## Guardrails — when to stop and ask
+
+- **Never pin a transitive dep *lower* than a sibling already requires** — it
+  won't build. Re-read rule C.2.
+- **Never satisfy a policy by weakening posture** (e.g. removing the non-root
+  `USER`, disabling the gate, adding to an allowlist) to make CI green. Fix the
+  finding.
+- **Unfixable CVE (no `--only-fixed` hit, no upstream fix yet):** there's no
+  clean bump. Don't force one. Record it (the non-blocking SARIF/quickview steps
+  already track totals) and, if it blocks a release policy, surface it to a human
+  with the CVE id and why no fix exists — don't broaden `--only-policy` silently.
+- **A base-image major bump that breaks the build** (musl/glibc, tool incompat)
+  is a judgment call — fix forward if straightforward, else stop and ask.
+- **Touching `build-go-alpine`'s `USER` or base** ripples to downstream repos.
+  Confirm the downstream coordination (section D) is done before a release.

--- a/.claude/skills/scout-fix/SKILL.md
+++ b/.claude/skills/scout-fix/SKILL.md
@@ -144,8 +144,11 @@ Rules learned the hard way (#77):
 
 The three required images are **already non-root**: `build-api` and
 `build-go-alpine` default to user `build` (uid 1000), `service-base-alpine` to
-`nobody` (#78). A routine CVE fix never touches this; the PR gate's non-root
-assertion just stops a regression. **Don't re-add what's already there.**
+`nobody` (#78). A routine CVE fix never touches this; the PR-time `non-root-audit`
+job statically checks **every** image's final-stage USER and hard-fails only if a
+*required* one regresses to root (the other images — 6 currently default to root
+— are reported, not gated, since making them non-root is a breaking change for
+their consumers). **Don't re-add what's already there.**
 
 You apply this pattern only when a **brand-new image joins the required set**.
 Then add a uid-1000 user **after all privileged setup** (`apk add`/`apt`, `git

--- a/.claude/skills/scout-fix/SKILL.md
+++ b/.claude/skills/scout-fix/SKILL.md
@@ -155,15 +155,10 @@ Alpine: `addgroup -g 1000 build && adduser -D -u 1000 -G build -h /home/build
 build`. Go caches stay writable because `/go` is mode 1777 and `GOCACHE=/tmp`
 is 1777.
 
-⚠️ **The downstream coordination is a RELEASE precondition, not a CVE-fix step.**
-If the new image is a `FROM` base for downstream multi-stage builds (as
-`build-go-alpine` is for ui-core `Dockerfile-go` and anything on the shared
-`common.go.mk` pattern), each consumer's build stage **inherits the `USER`** and
-fails writing the root-owned `/go/pkg/mod` cache mount — so every consumer must
-add `USER root` to its build stage *before* it bumps `BUILDENV_TAG` to a release
-carrying the non-root default. This is owned by whoever cuts the release (see the
-README non-root section), not by your finding fix. The prod stage (`FROM
-service-base-alpine`) is unaffected — it stays `nobody`.
+The non-root migration was a **one-time coordinated breaking change** — because
+`build-go-alpine` is a `FROM` base, consumers had to add `USER root` to their
+build stages first (#78) — and it is **complete**. Don't reintroduce that class
+of change in a routine fix; see "keep fixes non-breaking" in Guardrails.
 
 ---
 
@@ -204,7 +199,16 @@ luthersystems/<img>:<ver> --raw` (expect per-platform in-toto manifests).
   clean bump. Don't force one. Record it (the non-blocking SARIF/quickview steps
   already track totals) and, if it blocks a release policy, surface it to a human
   with the CVE id and why no fix exists — don't broaden `--only-policy` silently.
-- **A base-image major bump that breaks the build** (musl/glibc, tool incompat)
-  is a judgment call — fix forward if straightforward, else stop and ask.
-- **Touching `build-go-alpine`'s `USER` or base** ripples to downstream repos.
-  Confirm the downstream coordination (section D) is done before a release.
+- **Keep fixes non-breaking — this is the maintenance contract.** Regular Scout
+  upkeep is version bumps (A/B/C) that don't change a published image's runtime
+  contract. Do **not** alter a published image's default `USER`, `ENTRYPOINT`,
+  base distro/ABI, or anything a downstream `FROM`/`docker run` consumer relies
+  on as part of a fix — that's a coordinated breaking release (the one-time #78
+  non-root migration was the last one), not routine work. If clearing a finding
+  seems to require it, stop and escalate to a human.
+- **Prefer the minimal bump that clears the finding.** Patch/minor bumps of a
+  base or tool are safe and are what regular maintenance should apply
+  automatically. A **major** bump (alpine/golang major, a tool's vN→vN+1, Node
+  major) can change behavior or CLI flags that downstream consumers depend on —
+  treat it as potentially breaking: take it only if a patch/minor doesn't clear
+  the finding, and flag it for human review instead of auto-merging.

--- a/.claude/skills/scout-fix/SKILL.md
+++ b/.claude/skills/scout-fix/SKILL.md
@@ -207,8 +207,11 @@ luthersystems/<img>:<ver> --raw` (expect per-platform in-toto manifests).
   non-root migration was the last one), not routine work. If clearing a finding
   seems to require it, stop and escalate to a human.
 - **Prefer the minimal bump that clears the finding.** Patch/minor bumps of a
-  base or tool are safe and are what regular maintenance should apply
-  automatically. A **major** bump (alpine/golang major, a tool's vN→vN+1, Node
-  major) can change behavior or CLI flags that downstream consumers depend on —
-  treat it as potentially breaking: take it only if a patch/minor doesn't clear
-  the finding, and flag it for human review instead of auto-merging.
+  base or tool are low-risk and are what regular maintenance normally applies
+  automatically — but watch a tool bump that changes *behavior* even without a
+  major (e.g. `golangci-lint` surfacing new lint in consumer CI); apply the
+  minimal version that clears the finding. A **major** bump (alpine/golang major,
+  a tool's vN→vN+1, Node major) can change behavior, CLI flags, or ABI that
+  downstream consumers depend on — treat it as potentially breaking: take it only
+  if no patch/minor clears the finding, and flag it for human review instead of
+  auto-merging.

--- a/.claude/skills/verify-scout/SKILL.md
+++ b/.claude/skills/verify-scout/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: verify-scout
+description: "Confirm the grade-A build images are still clean BEFORE opening a PR — the local mirror of the CI Scout gates. Use after touching any image, common.config.mk, or a Dockerfile, and as the self-check step at the end of /scout-fix. Examples: 'verify the scout gate locally', 'is build-go-alpine still grade A', 'check before PR'."
+---
+
+# Verify the grade-A bill of health locally
+
+Run this before opening any PR that touches `images/`, `common.config.mk`, or a
+Dockerfile. It reproduces the two PR-time gates (`build.yml` → `cve-scan`) so you
+catch a regression locally instead of in CI. The required set is read from
+`.github/scout-required-images.json`.
+
+## Run it
+
+```bash
+cd images
+sha=$(git rev-parse HEAD)
+fail=0
+for img in $(jq -r '.required[]' ../.github/scout-required-images.json); do
+  echo "═══ $img ═══"
+  make PLATFORMS=linux/amd64 DOCKER_BUILDX_OPTS=--load GIT_REVISION="$sha" "$img"
+  ref="local://luthersystems/${img}:${sha}"
+
+  # Gate 1 — fixable CRITICAL/HIGH CVEs (must be ZERO)
+  docker scout cves "$ref" --only-fixed --only-severities critical,high --exit-code \
+    || { echo "❌ $img: fixable CRITICAL/HIGH CVE(s)"; fail=1; }
+
+  # Gate 2 — default non-root user (must be non-empty and not root/0)
+  user=$(docker image inspect "luthersystems/${img}:${sha}" --format '{{.Config.User}}')
+  case "$user" in
+    ""|root|0|0:0|root:root) echo "❌ $img: default USER='$user' is root"; fail=1 ;;
+    *) echo "✅ $img: USER='$user'" ;;
+  esac
+
+  docker scout quickview "$ref"   # eyeball the full C/H/M/L + policy picture
+done
+[ "$fail" -eq 0 ] && echo "✅ all required images clean" || { echo "❌ regressions above"; exit 1; }
+```
+
+## What "OK" looks like
+
+- **Gate 1:** `docker scout cves … --only-fixed --only-severities critical,high`
+  exits 0 with no rows for every required image.
+- **Gate 2:** every required image reports a non-root `USER` (`build`, uid `1000`,
+  or `nobody` for service-base-alpine).
+- `quickview` shows no *fixable* HIGH/CRITICAL and ideally `0C 0H` overall.
+
+## What this CANNOT verify locally (by design)
+
+- **Supply-chain attestations** and the **true A–F grade** only exist on the
+  *pushed* image — a `--load` build carries no attestations. Those are enforced
+  at release by `publish.yml` → `scout-policy` (`docker scout policy --exit-code`)
+  and `verify-attestations`. Don't try to attest a `--load` build.
+- **Unfixable** CVEs won't fail Gate 1 (it's `--only-fixed`); they're tracked
+  non-blocking in CI. Drop the `--only-fixed` flag if you want to see the total.
+
+If anything is red, go back to **`/scout-fix`** and pick the matching fix pattern.

--- a/.github/actions/configure-dockerhub/action.yml
+++ b/.github/actions/configure-dockerhub/action.yml
@@ -1,4 +1,5 @@
 name: configure-dockerhub
+description: Log in to Docker Hub when DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are set (no-op otherwise).
 runs:
   using: composite
   steps:

--- a/.github/scout-required-images.json
+++ b/.github/scout-required-images.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Single source of truth for the Docker Scout 'clean bill of health' image set. Every image under `required` must earn a grade-A Docker Scout health score. CI enforces this in two places, both driven by this file (via the scout-config job): (1) PR time, .github/workflows/build.yml gates the policies that are deterministically checkable on a locally-built image -- fixable CRITICAL/HIGH CVEs and the default-non-root-user policy; (2) release time, .github/workflows/publish.yml runs `docker scout policy --exit-code` on the PUSHED image, which is the only place the true grade can be evaluated because supply-chain attestations (15 pts) only attach on push and base-image / high-profile-CVE / license policies are computed registry-side. `cve_net_extra` lists extra builder images that get the fixable CRITICAL/HIGH CVE net only, NOT the full grade-A bill of health. To require a new service, add it to `required` (and add the matching non-root USER + clean deps first). See README 'Image security policies'.",
+  "required": [
+    "build-api",
+    "build-go-alpine",
+    "service-base-alpine"
+  ],
+  "cve_net_extra": [
+    "build-go"
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,27 +126,6 @@ jobs:
           path: scout-cves-${{ matrix.image }}.sarif
           if-no-files-found: warn
 
-      # Hard gate: Docker Scout "default non-root user" policy (health-score,
-      # 5 pts). Deterministic and locally checkable, so we enforce it at PR time
-      # rather than waiting for the release-time grade. Scoped to the required
-      # grade-A set (build-go gets the CVE net only). The image was loaded
-      # locally above as luthersystems/<image>:<sha>. Regression guard for the
-      # non-root default that landed in #78.
-      - name: Assert non-root default USER (Docker Scout policy)
-        if: contains(fromJSON(needs.scout-config.outputs.required), matrix.image)
-        run: |
-          set -euo pipefail
-          tag=luthersystems/${{ matrix.image }}:${{ github.sha }}
-          user=$(docker image inspect "$tag" --format '{{.Config.User}}')
-          echo "${{ matrix.image }} default USER='${user}'"
-          case "${user}" in
-            ""|root|0|0:0|root:root)
-              echo "::error::${{ matrix.image }} has no non-root default USER ('${user}'): violates Docker Scout 'default non-root user' policy. Add a non-root USER to images/Dockerfile.${{ matrix.image }} (see #78)."
-              exit 1
-              ;;
-          esac
-          echo "✅ ${{ matrix.image }} defaults to a non-root user"
-
       # Hard gate: fail the build on any FIXABLE HIGH/CRITICAL CVE.
       - name: Scan with Docker Scout (fail on fixable HIGH/CRITICAL)
         uses: docker/scout-action@7520205ff60037fdc436b40b6a1d1e55a839ec2d  # v1.22.0
@@ -159,3 +138,55 @@ jobs:
           write-comment: false
           dockerhub-user: ${{ env.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ env.DOCKERHUB_TOKEN }}
+
+  # Non-root default-USER audit across ALL images (Docker Scout "default non-root
+  # user" policy). Static — reads each Dockerfile's final-stage USER, so it needs
+  # no image build. HARD-FAILS only if a required grade-A image (from
+  # scout-required-images.json) regresses to root — that would drop its grade.
+  # Every other image is REPORTED, not gated: making a currently-root builder
+  # non-root is a #78-class breaking change for its `docker run`/`FROM` consumers,
+  # so it's surfaced as an inventory for deliberate future hardening, never
+  # slipped in here. The step summary lists the current root images.
+  non-root-audit:
+    name: Non-root user audit (all images)
+    needs:
+      - scout-config
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Audit every image Dockerfile for a non-root default USER
+        env:
+          REQUIRED: ${{ needs.scout-config.outputs.required }}
+        run: |
+          set -euo pipefail
+          required=$(echo "$REQUIRED" | jq -r '.[]')
+          is_required() { for r in $required; do [ "$r" = "$1" ] && return 0; done; return 1; }
+          fail=0
+          {
+            echo "## Non-root default USER audit (all images)"
+            echo
+            echo "| Image | Final-stage USER | Status |"
+            echo "|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          for f in images/Dockerfile.*; do
+            img=${f#images/Dockerfile.}
+            # final-stage USER: reset on each FROM, keep the last USER seen
+            user=$(awk '/^[[:space:]]*FROM /{su=""} /^[[:space:]]*USER /{su=$2} END{print su}' "$f")
+            case "$user" in
+              ""|root|0|0:0|root:root)
+                if is_required "$img"; then
+                  echo "| \`$img\` | _(root)_ | ❌ required image must be non-root |" >> "$GITHUB_STEP_SUMMARY"
+                  echo "::error file=images/Dockerfile.$img::$img is a required grade-A image but defaults to root — add a non-root USER (see #78)."
+                  fail=1
+                else
+                  echo "| \`$img\` | _(root)_ | ⚠️ root — not gated (see comment) |" >> "$GITHUB_STEP_SUMMARY"
+                  echo "::warning file=images/Dockerfile.$img::$img defaults to root. Not gated: making it non-root is a breaking change for its consumers. Tracked for deliberate hardening."
+                fi
+                ;;
+              *)
+                echo "| \`$img\` | \`$user\` | ✅ non-root |" >> "$GITHUB_STEP_SUMMARY"
+                ;;
+            esac
+          done
+          echo "::notice::Non-root audit complete; see the job summary for the full table."
+          [ "$fail" -eq 0 ] || { echo "A required grade-A image defaults to root — see errors above."; exit 1; }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,38 @@ jobs:
           image: ${{ matrix.image }}
           git_rev: $GITHUB_SHA
 
+  # Single source of truth for which images must carry a clean Docker Scout
+  # bill of health lives in .github/scout-required-images.json. This job
+  # publishes it as outputs so both the PR gate (below) and the release gate
+  # (publish.yml) consume the same list — add a service THERE, not here.
+  scout-config:
+    name: Resolve Docker Scout image lists
+    runs-on: ubuntu-22.04
+    outputs:
+      required: ${{ steps.lists.outputs.required }}
+      cve: ${{ steps.lists.outputs.cve }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Load Docker Scout image lists
+        id: lists
+        run: |
+          set -euo pipefail
+          f=.github/scout-required-images.json
+          jq -e . "$f" >/dev/null
+          echo "required=$(jq -c '.required' "$f")" >> "$GITHUB_OUTPUT"
+          echo "cve=$(jq -c '.required + .cve_net_extra' "$f")" >> "$GITHUB_OUTPUT"
+
   cve-scan:
     name: CVE scan (${{ matrix.image }})
+    needs:
+      - scout-config
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - build-api
-          - build-go
-          - build-go-alpine
-          - service-base-alpine
+        # Required grade-A images + the CVE-net-only builders, sourced from
+        # .github/scout-required-images.json via the scout-config job.
+        image: ${{ fromJSON(needs.scout-config.outputs.cve) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Configure DockerHub
@@ -104,6 +125,27 @@ jobs:
           name: scout-cves-${{ matrix.image }}
           path: scout-cves-${{ matrix.image }}.sarif
           if-no-files-found: warn
+
+      # Hard gate: Docker Scout "default non-root user" policy (health-score,
+      # 5 pts). Deterministic and locally checkable, so we enforce it at PR time
+      # rather than waiting for the release-time grade. Scoped to the required
+      # grade-A set (build-go gets the CVE net only). The image was loaded
+      # locally above as luthersystems/<image>:<sha>. Regression guard for the
+      # non-root default that landed in #78.
+      - name: Assert non-root default USER (Docker Scout policy)
+        if: contains(fromJSON(needs.scout-config.outputs.required), matrix.image)
+        run: |
+          set -euo pipefail
+          tag=luthersystems/${{ matrix.image }}:${{ github.sha }}
+          user=$(docker image inspect "$tag" --format '{{.Config.User}}')
+          echo "${{ matrix.image }} default USER='${user}'"
+          case "${user}" in
+            ""|root|0|0:0|root:root)
+              echo "::error::${{ matrix.image }} has no non-root default USER ('${user}'): violates Docker Scout 'default non-root user' policy. Add a non-root USER to images/Dockerfile.${{ matrix.image }} (see #78)."
+              exit 1
+              ;;
+          esac
+          echo "✅ ${{ matrix.image }} defaults to a non-root user"
 
       # Hard gate: fail the build on any FIXABLE HIGH/CRITICAL CVE.
       - name: Scan with Docker Scout (fail on fixable HIGH/CRITICAL)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,18 +49,33 @@ jobs:
       - name: Create and push manifest for multiarch
         run: cd images && make push-manifests GIT_TAG=$GITHUB_REF_NAME
 
+  # Single source of truth for the grade-A image set, shared with the PR gate
+  # in build.yml. Add a service in .github/scout-required-images.json, not here.
+  scout-config:
+    name: Resolve Docker Scout image lists
+    runs-on: ubuntu-22.04
+    outputs:
+      required: ${{ steps.lists.outputs.required }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Load Docker Scout image lists
+        id: lists
+        run: |
+          set -euo pipefail
+          f=.github/scout-required-images.json
+          jq -e . "$f" >/dev/null
+          echo "required=$(jq -c '.required' "$f")" >> "$GITHUB_OUTPUT"
+
   cve-scan:
     name: CVE scan published image (${{ matrix.image }})
     runs-on: ubuntu-22.04
     needs:
       - push-manifests
+      - scout-config
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - build-api
-          - build-go-alpine
-          - service-base-alpine
+        image: ${{ fromJSON(needs.scout-config.outputs.required) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -77,6 +92,43 @@ jobs:
           write-comment: false
           dockerhub-user: ${{ env.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ env.DOCKERHUB_TOKEN }}
+
+  # Release-time TRUE grade-A gate. The Docker Scout health grade (A–F) and its
+  # supply-chain-attestation / approved+up-to-date base-image / high-profile-CVE
+  # / license policies are computed registry-side on the PUSHED image, so this is
+  # the only place the real "A A A" bill of health can be enforced (a PR's local
+  # --load image structurally can't carry attestations, so it can't grade A).
+  # `docker scout policy --exit-code` returns non-zero if ANY org policy is
+  # non-compliant on the published image. Escape hatch if an UNFIXABLE CVE or a
+  # newly-added low-weight policy ever blocks an otherwise-good release: scope
+  # with `--only-policy <slug,...>`, or temporarily add `continue-on-error: true`.
+  # Runs on the required grade-A set from .github/scout-required-images.json.
+  scout-policy:
+    name: Scout policy grade (${{ matrix.image }})
+    runs-on: ubuntu-22.04
+    needs:
+      - push-manifests
+      - scout-config
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.scout-config.outputs.required) }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Configure DockerHub
+        uses: ./.github/actions/configure-dockerhub
+      - name: Install Docker Scout CLI
+        run: curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
+      - name: Evaluate Docker Scout policies on the published image
+        env:
+          DOCKER_SCOUT_HUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
+          DOCKER_SCOUT_HUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          docker scout policy luthersystems/${{ matrix.image }}:${{ github.ref_name }} \
+            --org luthersystems \
+            --exit-code
 
   # Gate the release on supply-chain attestations actually being present on the
   # PUBLISHED multi-arch image. The Makefile attaches SBOM + provenance during

--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -1,0 +1,94 @@
+name: Scout drift watch
+
+# Layer 2 of keeping the required images at grade A (see README "Image security
+# policies"). The PR gate (build.yml) and release gate (publish.yml) only fire
+# on code changes — but a CVE disclosed today against an UNCHANGED pin drops the
+# grade with no commit to trigger a scan. This weekly cron re-evaluates the
+# real Docker Scout policy grade on the published `:latest` images and opens (or
+# refreshes) a tracking issue + reds the run when any required image falls below
+# grade A. It reads the same single source of truth,
+# .github/scout-required-images.json.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+
+jobs:
+  drift:
+    name: Docker Scout drift watch (published :latest)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Configure DockerHub
+        uses: ./.github/actions/configure-dockerhub
+      - name: Install Docker Scout CLI
+        run: curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
+      - name: Evaluate Scout policy on each required :latest image
+        id: scan
+        env:
+          DOCKER_SCOUT_HUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
+          DOCKER_SCOUT_HUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          drift=0
+          {
+            echo "## Docker Scout policy drift on published \`:latest\` images"
+            echo
+            echo "Re-evaluated by the weekly \`Scout drift watch\` workflow."
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+          } > summary.md
+          for img in $(jq -r '.required[]' .github/scout-required-images.json); do
+            echo "::group::scout policy luthersystems/${img}:latest"
+            if docker scout policy "luthersystems/${img}:latest" --org luthersystems --exit-code; then
+              echo "- ✅ \`${img}\` — grade A (all policies compliant)" >> summary.md
+            else
+              echo "- ❌ \`${img}\` — policy non-compliant (dropped below grade A)" >> summary.md
+              drift=1
+            fi
+            echo "::endgroup::"
+          done
+          echo "drift=${drift}" >> "$GITHUB_OUTPUT"
+          echo "----- summary -----"; cat summary.md
+      - name: Open or refresh the drift issue
+        if: steps.scan.outputs.drift == '1'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('summary.md', 'utf8');
+            const title = 'Docker Scout: published image(s) dropped below grade A';
+            const { owner, repo } = context.repo;
+            const open = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
+            });
+            if (open.data.length) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: open.data[0].number, body,
+              });
+              core.info(`Refreshed existing issue #${open.data[0].number}`);
+            } else {
+              try {
+                await github.rest.issues.createLabel({
+                  owner, repo, name: 'scout-drift', color: 'b60205',
+                  description: 'A published image fell below Docker Scout grade A',
+                });
+              } catch (e) { /* label already exists */ }
+              const created = await github.rest.issues.create({
+                owner, repo, title, body, labels: ['scout-drift'],
+              });
+              core.info(`Opened issue #${created.data.number}`);
+            }
+      - name: Fail the run if drift detected
+        if: steps.scan.outputs.drift == '1'
+        run: |
+          echo "::error::One or more published images dropped below Docker Scout grade A — see the 'scout-drift' issue."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+Guidance for coding agents working in **buildenv** — the common build and run
+containers for Luther applications. Shared with Codex via the `AGENTS.md`
+symlink. Global agent rules come from your client.
+
+**Also read:** [README.md](README.md) → "Image security policies" for the
+grade-A model and the two-tier CI gate.
+
+## What this repo is
+
+A set of multi-arch Docker images (in `images/`) published to Docker Hub under
+`luthersystems/<image>`. Downstream repos pin a release via `BUILDENV_TAG` and
+consume these as `docker run` tools or as `FROM` bases in multi-stage builds.
+
+| Image | Role |
+|---|---|
+| `build-api`, `build-go`, `build-go-alpine`, `build-godynamic` | Go build/test/lint toolchains |
+| `build-js`, `build-java`, `build-e2e`, `build-swaggercodegen` | JS / Java / e2e / codegen toolchains |
+| `nginx-frontend` | Static frontend serving base |
+| `service-base-alpine` | Minimal **prod runtime** base (runs as `nobody`) |
+
+## Build & test
+
+```bash
+# Build locally (single arch, loaded into the local daemon)
+cd images && make PLATFORMS=$(../scripts/local_platform.sh) DOCKER_BUILDX_OPTS=--load <image>
+
+# Build one image for an explicit platform
+cd images && make PLATFORMS=linux/amd64 DOCKER_BUILDX_OPTS=--load build-go-alpine
+```
+
+There is no unit-test suite; correctness is "the image builds multi-arch and
+passes the Docker Scout gate." Releases happen on `v*` tag push (publish.yml) —
+created via the GitHub release UI.
+
+## Versions are centralized — change them in ONE place
+
+**All tool/base versions live in [`common.config.mk`](common.config.mk)** (Go,
+Alpine, golangci-lint, buf, go-swagger, git-lfs, aws/az CLI, node, …). The
+Dockerfiles take them as `ARG`s; the Makefile passes the central value at build.
+Dockerfile `ARG <X>=<default>` lines are fallbacks only — when you bump a
+version, bump `common.config.mk`, and update the matching `ARG` default if it
+drifts (CI builds use the central value regardless).
+
+## Docker Scout grade-A bill of health
+
+Three images **must** stay at Docker Scout grade A:
+`build-api`, `build-go-alpine`, `service-base-alpine`. The required set is the
+single source of truth in
+[`.github/scout-required-images.json`](.github/scout-required-images.json) and is
+gated in CI three ways:
+
+| When | Workflow | Gate |
+|---|---|---|
+| every PR | `build.yml` → `cve-scan` | fixable CRITICAL/HIGH CVEs + default-non-root-user |
+| release (tag) | `publish.yml` → `scout-policy` | `docker scout policy --exit-code` (true grade) + attestations |
+| weekly cron | `scout-drift.yml` | re-scan published `:latest`; opens a `scout-drift` issue on drift |
+
+**When a Scout finding (CVE or policy) needs fixing, follow the `/scout-fix`
+skill — it captures exactly how #71/#72, #74, #76, #77, #78 were resolved.**
+Verify with `/verify-scout` before opening a PR.
+
+## Critical rules
+
+1. **Never push to `main`.** Branch, PR, human review. Releases are tagged by a
+   human (a base-image change can require coordinated downstream edits — see #78
+   and the non-root note in README).
+2. **Pin, don't float, security-driven dep bumps in from-source tool builds.**
+   The `go get …@vX` transitive pins in the Dockerfiles exist to clear specific
+   CVEs; keep them explicit and annotated. See `/scout-fix`.
+3. **Respect the non-root downstream contract.** `build-go-alpine` is a `FROM`
+   base; changing its default `USER` can break consumers' build stages. See #78.
+4. **Pin GitHub Actions to SHAs** (Dependabot `actions` group keeps them current).
+
+## Skills
+
+Prescriptive SOPs in `.claude/skills/<name>/SKILL.md`. Scan this table at the
+start of a task and follow the matching skill exactly.
+
+| Skill | When to use |
+|---|---|
+| `/scout-fix` | A Docker Scout CVE or policy finding on a build image needs fixing (CI gate red, drift issue, or a customer/Allianz report) |
+| `/verify-scout` | Before opening a PR that touches an image — confirm the grade-A images are still clean locally |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,12 @@ Verify with `/verify-scout` before opening a PR.
 2. **Pin, don't float, security-driven dep bumps in from-source tool builds.**
    The `go get …@vX` transitive pins in the Dockerfiles exist to clear specific
    CVEs; keep them explicit and annotated. See `/scout-fix`.
-3. **Respect the non-root downstream contract.** `build-go-alpine` is a `FROM`
-   base; changing its default `USER` can break consumers' build stages. See #78.
+3. **Keep published-image changes non-breaking.** Regular security upkeep is
+   version bumps that don't change an image's runtime contract. Changing a
+   published image's default `USER`, entrypoint, or base ABI can break downstream
+   `FROM`/`docker run` consumers — that's a coordinated breaking release (the #78
+   non-root migration was the last one), not routine maintenance. Prefer the
+   minimal patch/minor bump; escalate a major/contract-changing bump for review.
 4. **Pin GitHub Actions to SHAs** (Dependabot `actions` group keeps them current).
 
 ## Skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,13 @@ Verify with `/verify-scout` before opening a PR.
 
 ## Critical rules
 
-1. **Never push to `main`.** Branch, PR, human review. Releases are tagged by a
-   human (a base-image change can require coordinated downstream edits — see #78
-   and the non-root note in README).
+1. **Never push to `main`; never self-merge.** Branch, PR, human review. `main`
+   is protected: the strict-image gates are required checks and a human approving
+   review is required, so **automation (the upkeep agent) opens PRs but a human
+   merges them** — the bot runs as a GitHub App with no bypass. Releases are
+   tagged by a human (a base-image change can require coordinated downstream
+   edits — see #78). Required-checks list + apply command:
+   [docs/BRANCH_PROTECTION.md](docs/BRANCH_PROTECTION.md).
 2. **Pin, don't float, security-driven dep bumps in from-source tool builds.**
    The `go get …@vX` transitive pins in the Dockerfiles exist to clear specific
    CVEs; keep them explicit and annotated. See `/scout-fix`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ gated in CI three ways:
 
 | When | Workflow | Gate |
 |---|---|---|
-| every PR | `build.yml` → `cve-scan` | fixable CRITICAL/HIGH CVEs + default-non-root-user |
+| every PR | `build.yml` → `cve-scan` + `non-root-audit` | fixable CRITICAL/HIGH CVEs (required set); non-root audit across **all** images — hard-fails only if a required image regresses to root, reports the rest |
 | release (tag) | `publish.yml` → `scout-policy` | `docker scout policy --exit-code` (true grade) + attestations |
 | weekly cron | `scout-drift.yml` | re-scan published `:latest`; opens a `scout-drift` issue on drift |
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ CVE or a newly-added low-weight policy, scope `scout-policy` with
 `--only-policy <slug,...>` or temporarily set `continue-on-error: true` — see the
 comment on that job in `publish.yml`.
 
+For the strict-image gates to actually **block merges** — and to ensure
+automation can open PRs but never merge them — the checks must be marked required
+in `main`'s branch protection. The exact required-checks list, settings, and a
+one-shot apply command are in
+[docs/BRANCH_PROTECTION.md](docs/BRANCH_PROTECTION.md).
+
 ### Supply-chain attestations
 
 Every published image carries SBOM + SLSA provenance attestations. These are

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ both reading the list above via the `scout-config` job:
 
 | Tier | Workflow | What it gates |
 |---|---|---|
-| **PR** (every PR) | `build.yml` → `cve-scan` | the policies that are deterministic on a locally-built image: **fixable CRITICAL/HIGH CVEs** + **default non-root user**. Fails the PR on regression. |
+| **PR** (every PR) | `build.yml` → `cve-scan` + `non-root-audit` | **fixable CRITICAL/HIGH CVEs** on the required set, plus a **non-root-user audit across all 10 images** — hard-fails only if a required image regresses to root, and reports every other image's status (the 6 root builders are surfaced, not gated). |
 | **Release** (tag push) | `publish.yml` → `scout-policy` | the **true grade** on the pushed image: `docker scout policy --exit-code` (covers attestations, approved/up-to-date base images, high-profile CVEs, and licenses on top of the above). Fails the release if any policy is non-compliant. |
 
 `cve_net_extra` in the JSON (currently `build-go`) lists extra builder images

--- a/README.md
+++ b/README.md
@@ -25,8 +25,44 @@ off the release pipeline.
 
 ## Image security policies
 
-The published images are scanned against Docker Scout policies. Two policy
-requirements affect how downstream repos consume these images:
+The published images are scanned against Docker Scout policies. CI enforces a
+grade-A "bill of health" on a defined set of images (below), and two policy
+requirements affect how downstream repos consume these images (further down).
+
+### Grade-A bill of health (required image list)
+
+A [Docker Scout health score](https://docs.docker.com/scout/policy/scores/) is a
+weighted A–F grade (A = >90% of points) over eight policies: severity-based CVEs
+(20), high-profile CVEs (20), supply-chain attestations (15), approved base
+images (15), up-to-date base images (10), SonarQube quality gates (10, off by
+default), default non-root user (5), and compliant licenses (5).
+
+The set of images that **must** stay grade A is the single source of truth in
+[`.github/scout-required-images.json`](.github/scout-required-images.json):
+
+```
+build-api  ·  build-go-alpine  ·  service-base-alpine
+```
+
+Because the real grade is computed registry-side on the **pushed** image — and
+~15 of those points (supply-chain attestations) can only attach on push, so a
+PR's local `--load` image can never grade A — CI enforces this in two tiers,
+both reading the list above via the `scout-config` job:
+
+| Tier | Workflow | What it gates |
+|---|---|---|
+| **PR** (every PR) | `build.yml` → `cve-scan` | the policies that are deterministic on a locally-built image: **fixable CRITICAL/HIGH CVEs** + **default non-root user**. Fails the PR on regression. |
+| **Release** (tag push) | `publish.yml` → `scout-policy` | the **true grade** on the pushed image: `docker scout policy --exit-code` (covers attestations, approved/up-to-date base images, high-profile CVEs, and licenses on top of the above). Fails the release if any policy is non-compliant. |
+
+`cve_net_extra` in the JSON (currently `build-go`) lists extra builder images
+that get the fixable CRITICAL/HIGH CVE net only — not the full grade-A gate.
+
+**To require a new service:** add it to `required` in the JSON. First give it a
+non-root default `USER` and clean deps, or the very first PR/release will fail
+the gate (which is the point). If a release is ever blocked by an *unfixable*
+CVE or a newly-added low-weight policy, scope `scout-policy` with
+`--only-policy <slug,...>` or temporarily set `continue-on-error: true` — see the
+comment on that job in `publish.yml`.
 
 ### Supply-chain attestations
 

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,115 @@
+# Branch protection — `main`
+
+Governance for the protected `main` branch. The goal: the CI gates that keep the
+strict grade-A images healthy are **merge-blocking**, and **automation can open
+PRs but never merge them** — a human always approves.
+
+> These settings are applied in repo **Settings → Branches** (or via the API
+> command below). They are not expressible as a committed file, so this doc is
+> the source of truth / runbook; keep it in sync when the required checks change.
+
+## Why this matters for automation
+
+The upkeep loop (weekly `scout-drift` → a scheduled Claude agent → PR) is designed
+to **propose** fixes, not ship them. The lock that enforces "propose, don't merge":
+
+- **Require a pull request + at least one approving review.** A GitHub App / bot
+  cannot supply an approving review, so its PR can't reach the required count on
+  its own — a human must approve.
+- **The automation runs as a dedicated GitHub App, never a human PAT or an admin**,
+  and is **not** added to any bypass / "allow specified actors" list. Apps are
+  subject to branch protection unless explicitly allowed to bypass — so don't.
+- Auto-merge (if enabled) is still safe: it only fires **after** required reviews
+  and checks are satisfied, so it can't skip the human approval.
+
+## Required status checks
+
+Strict (security/grade-A — **must** be required):
+
+- `Resolve Docker Scout image lists`
+- `Non-root user audit (all images)` — hard-fails only on a strict-image root regression
+- `CVE scan (build-api)`
+- `CVE scan (build-go-alpine)`
+- `CVE scan (service-base-alpine)`
+
+Build integrity for the strict images (**recommended** — don't merge a broken build):
+
+- `build-api - amd64 docker build`, `build-api - arm64 docker build`
+- `build-go-alpine - amd64 docker build`, `build-go-alpine - arm64 docker build`
+- `service-base-alpine - amd64 docker build`, `service-base-alpine - arm64 docker build`
+
+Optional (broader net): `CVE scan (build-go)` and the remaining
+`<image> - <arch> docker build` checks for the non-strict images.
+
+> The strict set tracks `.github/scout-required-images.json`. If you promote a
+> 4th image to strict there, add its `CVE scan (...)` and build checks here too.
+
+## Settings
+
+- **Require a pull request before merging** → Require approvals: **1**;
+  **Dismiss stale approvals when new commits are pushed** (so a bot can't push
+  after a human approves and then merge).
+- **Require status checks to pass** → add the checks above; **Require branches to
+  be up to date before merging**.
+- **Require conversation resolution before merging**.
+- **Do not allow bypassing the above settings** (enforce on admins too) — strongest
+  "automation/no-one merges around the gate" guarantee. Trade-off: human admins
+  can't hotfix-merge either; relax only if you need that.
+- **Do not** add the automation App (or anyone) to "Allow specified actors to
+  bypass required pull requests."
+- Block force pushes and branch deletion (defaults for a protected branch).
+- Optional: add a `.github/CODEOWNERS` and enable **Require review from Code
+  Owners** to pin who must approve image changes.
+
+## Apply via API (one shot)
+
+An admin can apply the strict + recommended set with `gh`:
+
+```bash
+cat > /tmp/buildenv-main-protection.json <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Resolve Docker Scout image lists",
+      "Non-root user audit (all images)",
+      "CVE scan (build-api)",
+      "CVE scan (build-go-alpine)",
+      "CVE scan (service-base-alpine)",
+      "build-api - amd64 docker build",
+      "build-api - arm64 docker build",
+      "build-go-alpine - amd64 docker build",
+      "build-go-alpine - arm64 docker build",
+      "service-base-alpine - amd64 docker build",
+      "service-base-alpine - arm64 docker build"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+
+gh api -X PUT repos/luthersystems/buildenv/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  --input /tmp/buildenv-main-protection.json
+```
+
+Verify:
+
+```bash
+gh api repos/luthersystems/buildenv/branches/main/protection \
+  --jq '{checks: .required_status_checks.contexts, reviews: .required_pull_request_reviews.required_approving_review_count, admins: .enforce_admins.enabled}'
+```
+
+> Note: a required check that never reports (e.g. its job was skipped because an
+> upstream job failed) leaves the PR un-mergeable — which is the intended
+> fail-closed behavior.


### PR DESCRIPTION
## What

Codifies the "A A A" outcome of the #71/#72 → #78 epic into a standing CI system so `build-api`, `build-go-alpine`, and `service-base-alpine` stay at a Docker Scout grade-A health score, and captures the fix playbook so the upkeep can be driven without re-discovering it.

## Single source of truth

`.github/scout-required-images.json` — the list of images that must stay grade A. Both the PR gate and the release gate read it via a small `scout-config` job, so adding a service later is a one-line edit (plus a `cve_net_extra` list for builders that get the CVE net only, e.g. `build-go`).

## The three layers

- **Gate (PR + release)** — `build.yml`: the existing fixable CRITICAL/HIGH CVE gate plus a new deterministic **default-non-root-user** assertion (the two policies checkable on a local `--load` image). `publish.yml`: a new `scout-policy` job runs the real `docker scout policy --exit-code` on each pushed image — the only place the true grade exists (attestations only attach on push), covering attestations + approved/up-to-date base images + high-profile CVEs + licenses.
- **Drift watch (weekly)** — `scout-drift.yml`: re-evaluates the policy grade on the published `:latest` images on a cron, opens/refreshes a `scout-drift` issue, and reds the run when any required image falls below grade A. Catches a CVE disclosed against an unchanged pin (no commit would otherwise trigger a scan).
- **Fix playbook (agent skills)** — `CLAUDE.md` + `.claude/skills/scout-fix` and `verify-scout` capture exactly how #71/#72, #74, #76, #77, #78 were resolved: classify the finding, then apply one of OS apt/apk upgrade, central base bump, or the from-source transitive-pin pattern. The already-wired infrastructure (non-root, attestations) is documented as such, not as recurring steps.

## Maintenance contract: non-breaking by default

Encoded in the skill guardrails + `CLAUDE.md`: routine Scout upkeep is version bumps that don't change a published image's runtime contract (`USER` / entrypoint / base ABI). The #78 non-root migration was the one-time breaking exception. Prefer the minimal patch/minor bump; route major or behavior-changing bumps to human review instead of auto-merge.

## Not included (follow-up, needs a decision)

The scheduled `claude-code-action` workflow that actually runs the skills (drift issue → `/scout-fix` → `/verify-scout` → PR) is intentionally left out — it needs a GitHub App (so its PR triggers CI) and an `ANTHROPIC_API_KEY` secret. Easy to add once those are provisioned.

## Validation

- `actionlint` clean on `build.yml`, `publish.yml`, `scout-drift.yml`.
- `scout-required-images.json` validates; the `jq` list expressions produce the expected matrices.
- Existing required status-check names preserved (the non-root assertion rides inside the already-required `cve-scan` check); no branch-protection renames.
- Skill frontmatter parses as valid YAML.
- Note: the release `scout-policy` and `scout-drift` jobs only run on tag push / schedule, so their first live exercise is the next release / next Monday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY)_