### PR TITLE
ci: scout-autofix workflow (claude-code-action off the drift watch)

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -49,7 +49,7 @@ runs:
     # first-party actions/github-script action so buildx can talk to
     # whichever cache backend the runner is configured for.
     - name: Expose GHA runtime to buildx (for type=gha cache backend)
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
       with:
         script: |
           for (const [k, v] of Object.entries(process.env)) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
       - name: Expose GHA runtime to buildx (for type=gha cache backend)
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             for (const [k, v] of Object.entries(process.env)) {

--- a/.github/workflows/scout-autofix.yml
+++ b/.github/workflows/scout-autofix.yml
@@ -1,0 +1,65 @@
+name: Scout autofix
+
+# Layer 3 of the grade-A upkeep loop: turn a `Scout drift watch` failure into a
+# /scout-fix pull request, via the official Claude GitHub App (claude-code-action).
+# Branch protection on main means this can only PROPOSE — a human approves/merges
+# (docs/BRANCH_PROTECTION.md). Inert until the CLAUDE_CODE_OAUTH_TOKEN secret exists.
+#
+# Model auth today: a ~1-year Claude subscription token
+# (op://Reliable-Dev/CLAUDE_CODE_OAUTH_TOKEN -> repo secret CLAUDE_CODE_OAUTH_TOKEN).
+# Durable end state is Amazon Bedrock — see the swap block at the bottom and the
+# tracking issue.
+on:
+  workflow_run:
+    workflows: ["Scout drift watch"]
+    types: [completed]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write # lets claude-code-action mint the official Claude app token, so its PR triggers our required checks
+
+concurrency:
+  group: scout-autofix
+  cancel-in-progress: false
+
+jobs:
+  autofix:
+    name: Auto-fix Scout drift
+    # only when the weekly drift watch actually found a grade regression
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }} # so the skill's `docker scout` can authenticate
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0  (puts .claude/skills/scout-fix on disk)
+      - name: Run /scout-fix
+        uses: anthropics/claude-code-action@v1 # TODO: pin to a SHA (repo convention); the dependabot actions group will track it
+        with:
+          # Fast-bridge auth: 1-year Claude subscription token. If a future action
+          # version wants it as an env var instead, set CLAUDE_CODE_OAUTH_TOKEN in `env:`.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            /scout-fix
+            The weekly "Scout drift watch" workflow failed — read the open `scout-drift`
+            issue to see which strict grade-A image(s) dropped below grade A. Apply the
+            minimal NON-BREAKING fix per the skill, self-check with /verify-scout, and
+            open a PR. Do NOT merge — a human reviews. If the only findings are
+            unfixable CVEs, comment that on the scout-drift issue instead of opening a PR.
+          claude_args: |
+            --max-turns 30
+            --model claude-opus-4-8
+
+# ── Bedrock swap (durable billing — see tracking issue) ──────────────────────
+# 1. Delete the `claude_code_oauth_token:` line above and add to the action `with:`
+#       use_bedrock: "true"
+# 2. Add this step BEFORE the claude-code-action step:
+#       - uses: aws-actions/configure-aws-credentials@v4
+#         with:
+#           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}  # plt-or-<env>-luther-ci-buildenv-bedrock-role
+#           aws-region: us-west-2
+#    (`id-token: write` is already granted above.)

--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -60,7 +60,7 @@ jobs:
           echo "----- summary -----"; cat summary.md
       - name: Open or refresh the drift issue
         if: steps.scan.outputs.drift == '1'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## What

Layer 3 of the grade-A upkeep loop: when the weekly `Scout drift watch` fails, run `/scout-fix` via the official Claude GitHub App (`anthropics/claude-code-action`) to open a PR with the minimal non-breaking fix.

## How it's fenced

Branch protection on `main` (see `docs/BRANCH_PROTECTION.md`) requires a human approving review, and a GitHub App can't supply that approval — so this agent can only **propose**; a human reviews and merges. It also can't bypass the required checks.

## Triggers & bounds

- `workflow_run` off `Scout drift watch` (only when it concluded `failure`) + manual `workflow_dispatch`.
- `timeout-minutes: 30`, single-run `concurrency`.
- `id-token: write` so the action mints the official Claude app token — its PR triggers our required checks (the default `GITHUB_TOKEN` would not).
- Passes `DOCKERHUB_*` so the skill's `docker scout` can authenticate.

## Auth

Model auth is a ~1-year Claude subscription token (`CLAUDE_CODE_OAUTH_TOKEN`, set as an org secret). The Amazon Bedrock swap (durable AWS-native billing) is documented inline in the workflow and tracked in #82.

## Notes

- `claude-code-action@v1` is tag-pinned for now — TODO: SHA-pin per repo convention; the dependabot actions group will track it.
- Inert until merged. First verification after merge: a manual `workflow_dispatch` to confirm the run authenticates and the agent's PR triggers the required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY)_