### PR TITLE
ci: autonomous patch-release path for base-image-digest drift

### DIFF
--- a/.claude/skills/scout-fix/SKILL.md
+++ b/.claude/skills/scout-fix/SKILL.md
@@ -42,6 +42,7 @@ findings; `cves` tells you CVE findings.
 | Fixable CVE in a **bundled Go tool** (golangci-lint, buf, swagger, git-lfs, gotestsum…) | from-source build + pin the patched transitive dep | **C** |
 | Policy: **default non-root user** | already satisfied; only when a NEW image joins the set | **D** |
 | Policy: **supply-chain attestations** | already wired in Makefile/CI; not a Dockerfile fix | **E** |
+| Policy: **outdated base image** (stale published digest, the #80 class) | nothing to edit — cut a PATCH release to rebuild/republish | **F** |
 
 ---
 
@@ -182,14 +183,73 @@ luthersystems/<img>:<ver> --raw` (expect per-platform in-toto manifests).
 
 ---
 
-## Step N — Verify, then PR
+## F — Policy: outdated base image (stale published digest — republish, don't edit)
+
+This is the **#80 class**, and the one finding whose remedy is a **rebuild, not a
+source edit**. The published image embeds a base-image **digest** that has since
+gone stale: Docker periodically **re-pushes a floating base tag** (e.g.
+`golang:1.26.4`) onto a freshly-patched OS, so the tag now resolves to a newer
+digest than the one baked into the published image. Scout's "No outdated base
+images" policy flags it. The Dockerfile already pins the base by floating tag, so
+**there is nothing to change in `images/`** — a fresh build resolves the new
+digest on its own.
+
+**Confirm it's really this class** (run against the published image, not a local
+build — the drift is in what's published):
+```bash
+docker scout policy          "luthersystems/<img>:latest" --org luthersystems   # which policy failed?
+docker scout recommendations "luthersystems/<img>:latest"                       # expect "Refresh base image / Tag was pushed more recently"
+docker scout cves            "luthersystems/<img>:latest" --only-fixed --only-severities critical,high   # must be empty
+```
+You are in section F **only if** the *sole* failing policy is "No outdated base
+images", AND there are no fixable C/H CVEs, AND `common.config.mk` is already on
+the latest base patch (so B doesn't apply). If a real fixable CVE or a version
+bump is *also* needed, that part takes the A/B/C → PR path; F is purely the
+"nothing to edit, just republish" remedy.
+
+**Remedy — cut the next PATCH release (automation is allowed here):**
+A plain rebuild off unchanged source picks up the fresh base digest, and the only
+way to rebuild + republish in this repo is the release pipeline. So cut the next
+**patch** tag and let `publish.yml` do the rest (build every image, push,
+attestations, refresh `:latest` **and** the new `:vX.Y.Z`, then re-run the true
+`scout-policy` grade gate):
+```bash
+next=$(scripts/next-patch-version.sh)     # ALWAYS a patch bump, e.g. v0.1.5 -> v0.1.6
+gh release create "$next" --target main --title "$next" \
+  --notes "Automated base-image refresh: rebuild to pick up refreshed upstream base digests and restore Docker Scout grade A on the required images. No source changes."
+```
+
+Why this is safe to do **unattended**: it's a no-source-change rebuild; it's
+**patch-only** (minor/major imply a contract change and stay human — CLAUDE.md
+rule 1/3); nobody consumes `:latest` (consumers pin `BUILDENV_TAG=vX.Y.Z`), so the
+blast radius is nil; and `publish.yml`'s `scout-policy` gate is the backstop — if
+the rebuild doesn't reach grade A the release run reds and re-flags the issue.
+
+**Always pick the version with `scripts/next-patch-version.sh`** — never hand-type
+a tag. It refuses anything but a clean patch increment, which is what keeps
+automation inside the patch-only lane. After cutting the release, **do not open a
+PR** (there is no diff): note on the `scout-drift` issue that you cut `<tag>` to
+republish, and let the release run close it out.
+
+---
+
+## Step N — Verify, then PR (sections A–D) — or release (section F)
+
+**Section F (republish only)** has no diff to verify: you already confirmed the
+class, cut the patch release, and `publish.yml`'s gate is the check. Skip the rest
+of this step.
+
+**Sections A–D (a real source change):**
 
 1. Rebuild every image you touched and run **`/verify-scout`** — the grade-A
    images must show **0 fixable CRITICAL/HIGH** and a non-root `USER`.
 2. If you bumped `common.config.mk`, rebuild **every** image that consumes that
    ARG (a Go bump touches all Go images), not just the one that flagged.
 3. Open a PR. The `cve-scan` gate re-runs your check; the release `scout-policy`
-   gate enforces the true grade on the pushed image. A human cuts the tag.
+   gate enforces the true grade on the pushed image. A human merges. Cutting the
+   release that ships the fix stays human for a source change (it may warrant more
+   than a patch bump) — only the **section-F** no-source-change refresh is
+   auto-released, and only ever as a patch.
 
 ## Guardrails — when to stop and ask
 
@@ -198,6 +258,13 @@ luthersystems/<img>:<ver> --raw` (expect per-platform in-toto manifests).
 - **Never satisfy a policy by weakening posture** (e.g. removing the non-root
   `USER`, disabling the gate, adding to an allowlist) to make CI green. Fix the
   finding.
+- **Auto-release stays in the patch lane (section F only).** The only release
+  automation may cut unattended is the section-F no-source-change base refresh,
+  and only via `scripts/next-patch-version.sh` (which emits a patch bump or
+  refuses). Never auto-cut a minor/major, never auto-cut a release that carries a
+  source change, and never hand-pick a tag to route around the script. Anything
+  that seems to need more than a patch republish is a human decision — stop and
+  escalate on the issue.
 - **Unfixable CVE (no `--only-fixed` hit, no upstream fix yet):** there's no
   clean bump. Don't force one. Record it (the non-blocking SARIF/quickview steps
   already track totals) and, if it blocks a release policy, surface it to a human

--- a/.github/workflows/scout-autofix.yml
+++ b/.github/workflows/scout-autofix.yml
@@ -1,14 +1,25 @@
 name: Scout autofix
 
 # Layer 3 of the grade-A upkeep loop: turn a `Scout drift watch` failure into a
-# /scout-fix pull request, via the official Claude GitHub App (claude-code-action).
-# Branch protection on main means this can only PROPOSE — a human approves/merges
-# (docs/BRANCH_PROTECTION.md). Inert until the CLAUDE_CODE_OAUTH_TOKEN secret exists.
+# remediation, via the official Claude GitHub App (claude-code-action). The agent
+# reads the open `scout-drift` issue, reproduces with `docker scout`, and per the
+# /scout-fix skill takes ONE of three paths:
+#   * source-fixable finding (fixable CVE / base bump) -> open a PR (human merges)
+#   * stale base-image digest only (#80 class)         -> cut the next PATCH release
+#     (scripts/next-patch-version.sh + `gh release create`) so publish.yml
+#     rebuilds/republishes at grade A. Patch-only; nobody pins :latest; the
+#     release scout-policy gate is the backstop.
+#   * only unfixable CVEs                              -> comment on the issue
+#
+# Fences: branch protection means a PR can only be PROPOSED (a human merges); the
+# auto-release is constrained to a patch bump of a no-source-change refresh
+# (docs/BRANCH_PROTECTION.md, CLAUDE.md rule 1). Uses the official Claude App
+# (NOT a passed github_token) so the agent's PR and its `gh release create` both
+# trigger our required checks / publish.yml — the default GITHUB_TOKEN would not.
 #
 # Model auth today: a ~1-year Claude subscription token
 # (op://Reliable-Dev/CLAUDE_CODE_OAUTH_TOKEN -> repo secret CLAUDE_CODE_OAUTH_TOKEN).
-# Durable end state is Amazon Bedrock — see the swap block at the bottom and the
-# tracking issue.
+# Durable end state is Amazon Bedrock — see the swap block at the bottom and #82.
 on:
   workflow_run:
     workflows: ["Scout drift watch"]
@@ -16,10 +27,10 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+  contents: write # PR branch commits AND `gh release create` (the section-F patch release)
   pull-requests: write
   issues: write
-  id-token: write # lets claude-code-action mint the official Claude app token, so its PR triggers our required checks
+  id-token: write # lets claude-code-action mint the official Claude app token, so its PR / release triggers our required checks
 
 concurrency:
   group: scout-autofix
@@ -31,30 +42,70 @@ jobs:
     # only when the weekly drift watch actually found a grade regression
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 60 # rebuilding/scanning from source is heavy
     env:
       DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }} # so the skill's `docker scout` can authenticate
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKER_SCOUT_HUB_USER: ${{ vars.DOCKERHUB_USERNAME }} # so the skill's `docker scout` authenticates
+      DOCKER_SCOUT_HUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0  (puts .claude/skills/scout-fix on disk)
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0  (puts .claude/skills/scout-fix + scripts/ on disk)
+      - name: Configure DockerHub # log the runner's docker in so the agent's pulls / scout are authenticated
+        uses: ./.github/actions/configure-dockerhub
+      - name: Install Docker Scout CLI # pre-install so the agent doesn't spend a turn fetching it (observed in the validation trace)
+        run: curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
       - name: Run /scout-fix
         uses: anthropics/claude-code-action@v1 # TODO: pin to a SHA (repo convention); the dependabot actions group will track it
         with:
-          # Fast-bridge auth: 1-year Claude subscription token. If a future action
-          # version wants it as an env var instead, set CLAUDE_CODE_OAUTH_TOKEN in `env:`.
+          # Official-app auth (claude-code-action mints the app token via OIDC,
+          # using id-token: write above). Do NOT add a `github_token:` here — that
+          # makes the action skip the official-app exchange, and a default
+          # GITHUB_TOKEN does not trigger publish.yml / required checks, which the
+          # agent's release + PR depend on.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             /scout-fix
-            The weekly "Scout drift watch" workflow failed — read the open `scout-drift`
-            issue to see which strict grade-A image(s) dropped below grade A. Apply the
-            minimal NON-BREAKING fix per the skill, self-check with /verify-scout, and
-            open a PR. Do NOT merge — a human reviews. If the only findings are
-            unfixable CVEs, comment that on the scout-drift issue instead of opening a PR.
-          claude_args: |
-            --max-turns 30
-            --model claude-opus-4-8
+            The weekly "Scout drift watch" workflow failed. Read the open `scout-drift`
+            issue to see which strict grade-A image(s) dropped below grade A, reproduce
+            with `docker scout` per the skill, and remediate per the decision table:
 
-# ── Bedrock swap (durable billing — see tracking issue) ──────────────────────
+            - Source-fixable finding (fixable CVE in a pinned dep / OS package, or a
+              base bump): apply the minimal NON-BREAKING fix, self-check with
+              /verify-scout, and open a PR. Do NOT merge — a human reviews.
+            - Stale base-image digest ONLY (skill section F — "No outdated base images"
+              is the sole failing policy, no fixable CRITICAL/HIGH CVEs, base already on
+              the latest patch): there is no source fix. Cut the next PATCH release with
+              `scripts/next-patch-version.sh` + `gh release create` so publish.yml
+              rebuilds and republishes at grade A. PATCH ONLY — never minor/major, never
+              hand-pick a tag. Then note the tag on the scout-drift issue. Do NOT open a
+              PR (there is no diff).
+            - Only unfixable CVEs: comment that on the scout-drift issue; open nothing.
+
+            Never weaken posture to go green. When unsure which path applies, escalate
+            on the issue instead of guessing.
+          claude_args: |
+            --allowedTools Bash,Edit,Write,Read,Grep,Glob,MultiEdit
+            --max-turns 50
+            --model claude-opus-4-8
+      # Capture the agent's full stream-json conversation log for troubleshooting.
+      # claude-code-action hides the transcript from the job log ("full output
+      # hidden for security") and writes it to
+      # $RUNNER_TEMP/claude-execution-output.json, otherwise wiped on runner reclaim.
+      # always() so we capture even a failed/timed-out run. NOTE: this is a PUBLIC
+      # repo, so the artifact is repo-readable; the trace can contain secret-shaped
+      # strings the log-masker misses. Acceptable here (validated clean once, low
+      # value to an attacker), short retention as a backstop. If that ever stops
+      # being acceptable, route this to private storage instead of dropping it.
+      - name: Capture agent trace (conversation log)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scout-autofix-trace-${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          retention-days: 14
+          if-no-files-found: warn
+
+# ── Bedrock swap (durable billing — see tracking issue #82) ──────────────────
 # 1. Delete the `claude_code_oauth_token:` line above and add to the action `with:`
 #       use_bedrock: "true"
 # 2. Add this step BEFORE the claude-code-action step:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,14 @@ Verify with `/verify-scout` before opening a PR.
 1. **Never push to `main`; never self-merge.** Branch, PR, human review. `main`
    is protected: the strict-image gates are required checks and a human approving
    review is required, so **automation (the upkeep agent) opens PRs but a human
-   merges them** — the bot runs as a GitHub App with no bypass. Releases are
-   tagged by a human (a base-image change can require coordinated downstream
-   edits — see #78). Required-checks list + apply command:
-   [docs/BRANCH_PROTECTION.md](docs/BRANCH_PROTECTION.md).
+   merges them** — the bot runs as a GitHub App with no bypass. **Releases:**
+   automation may **auto-cut a _patch_ release** for a no-source-change base-image
+   refresh (the `:latest` Scout-drift / #80 class) — `publish.yml`'s `scout-policy`
+   gate is the backstop, nobody pins `:latest` (consumers pin `BUILDENV_TAG=vX.Y.Z`),
+   and `scripts/next-patch-version.sh` keeps it patch-only. **Minor/major releases,
+   and any release carrying a source change or a coordinated downstream edit (e.g.
+   a base-image change like #78), stay human-cut.** Required-checks list + apply
+   command: [docs/BRANCH_PROTECTION.md](docs/BRANCH_PROTECTION.md).
 2. **Pin, don't float, security-driven dep bumps in from-source tool builds.**
    The `go get …@vX` transitive pins in the Dockerfiles exist to clear specific
    CVEs; keep them explicit and annotated. See `/scout-fix`.

--- a/scripts/next-patch-version.sh
+++ b/scripts/next-patch-version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Compute the next PATCH version tag from the latest GitHub release.
+#
+# Used by the autonomous grade-A upkeep loop (the /scout-fix skill): when the
+# only Scout drift is a stale base-image digest — cured by a plain rebuild, with
+# no source change to PR (the #80 class) — the agent cuts the NEXT PATCH release
+# so publish.yml rebuilds + republishes the images at grade A. This script is the
+# ONLY sanctioned way to choose that version: it ALWAYS bumps just the patch
+# component, so automation can never land a minor/major bump (those imply a
+# contract change and stay human-cut — see CLAUDE.md rule 1/3).
+#
+# Prints e.g. `v0.1.6` to stdout. Exits non-zero (and emits nothing) if the
+# latest tag isn't a clean vMAJOR.MINOR.PATCH — don't guess, escalate to a human.
+set -euo pipefail
+
+# Latest release tag: prefer the GitHub release (what publish.yml + :latest
+# track); fall back to the highest semver git tag for local runs without gh.
+latest=""
+if command -v gh >/dev/null 2>&1 && latest=$(gh release view --json tagName -q .tagName 2>/dev/null) && [[ -n "${latest}" ]]; then
+  : # got it from gh
+else
+  latest=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)
+fi
+
+if [[ -z "${latest}" ]]; then
+  echo "error: could not determine the latest release tag" >&2
+  exit 1
+fi
+
+# Strict vMAJOR.MINOR.PATCH only. A pre-release, build-metadata, or otherwise
+# non-semver latest tag means something unusual is going on — refuse to auto-bump.
+if [[ ! "${latest}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "error: latest tag '${latest}' is not a clean vMAJOR.MINOR.PATCH; refusing to auto-bump (escalate to a human)" >&2
+  exit 2
+fi
+
+major="${BASH_REMATCH[1]}"
+minor="${BASH_REMATCH[2]}"
+patch="${BASH_REMATCH[3]}"
+echo "v${major}.${minor}.$((patch + 1))"


### PR DESCRIPTION
## What

Promotes the scout-autofix agent to production and gives the grade-A upkeep loop a third remediation path for the **#80 class** — a stale *published* base-image digest, which has no source fix (the cure is a rebuild, and the only rebuild trigger in this repo is a release).

## The three remediation paths

The agent reads the open `scout-drift` issue, reproduces with `docker scout`, and takes exactly one:

| Diagnosis | Action | Human in loop? |
|---|---|---|
| Source-fixable (fixable CVE in a pinned dep / OS pkg / base bump) | open a **PR** | yes — merges |
| **Stale base digest only (#80 class)** | **auto-cut next patch release** → `publish.yml` republishes at grade A | no |
| Only unfixable CVEs | comment on the issue | n/a |

## Changes

- **`scripts/next-patch-version.sh`** — emits the next patch tag from the latest release (`v0.1.5`→`v0.1.6`); refuses anything but a clean `vMAJOR.MINOR.PATCH`. Makes patch-only structural, so automation can't land a minor/major.
- **`.claude/skills/scout-fix/SKILL.md`** — new **section F** (outdated-base-image → cut the patch release via `gh release create` → `publish.yml` rebuilds/republishes), a decision-table row, Step N split (PR for A–D, release for F), and a patch-lane guardrail.
- **`.github/workflows/scout-autofix.yml`** — production config: Configure DockerHub + pre-install the Scout CLI, grant the tools `/scout-fix` needs, the three-branch prompt, capture the agent trace as an artifact, 60m / 50-turn budget. Official-app auth only (no `github_token`) so the agent's PR and its `gh release create` both trigger required checks / `publish.yml`.
- **`CLAUDE.md` rule 1** — automation may auto-cut a patch release for a no-source-change base refresh; minor/major and source-carrying releases stay human-cut.

## Why hands-off is safe here

- **Patch-only** — the script refuses anything else; minor/major imply a contract change and stay human (rule 1/3).
- **No source change** — it rebuilds unchanged Dockerfiles to pick up a refreshed upstream base digest.
- **Nobody pins `:latest`** — consumers pin `BUILDENV_TAG=vX.Y.Z`, so a refreshed `:latest` has no consumer blast radius.
- **`publish.yml`'s `scout-policy` gate is the backstop** — if a rebuild misses grade A, the release run reds and the drift issue is re-flagged.

## Fences unchanged

Branch protection still means a PR can only be proposed (a human merges). The only thing automation ships unattended is a patch republish of a no-source-change refresh.

## Validation / test plan

- `next-patch-version.sh`: `bash -n` clean; version math unit-tested (`v0.1.5→v0.1.6`, `v0.1.9→v0.1.10`; refuses `v1.2`, pre-release, non-semver).
- `scout-autofix.yml`: parses as valid YAML; the action `with:` block has no `github_token`; steps are checkout → Configure DockerHub → Install Scout CLI → Run /scout-fix → Capture trace.
- The agent harness was validated on a branch (16 turns, 0 permission denials, authenticated `docker scout`, correct #80 diagnosis).
- One link is only verifiable post-merge: whether the agent (as the official Claude App) can `gh release create` and trigger `publish.yml` — the official-app path can't run on a branch, so the first post-merge dispatch should be watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY)_