### PR TITLE
docs/ci: de-identify remediation SLA (remove customer name)

### DIFF
--- a/.claude/skills/scout-fix/SKILL.md
+++ b/.claude/skills/scout-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scout-fix
-description: "Resolve a Docker Scout finding (a CVE or a failed policy) on a build image and restore its grade-A bill of health. Use when a CI Scout gate is red, the weekly scout-drift issue fires, or a customer (e.g. Allianz) reports a Scout policy finding. Captures how #71/#72, #74, #76, #77, #78 were fixed. Examples: 'fix the fixable HIGH CVE in build-go-alpine', 'service-base-alpine dropped below grade A', 'clear the x/sys CVE in the go tools'."
+description: "Resolve a Docker Scout finding (a CVE or a failed policy) on a build image and restore its grade-A bill of health. Use when a CI Scout gate is red, the weekly scout-drift issue fires, or a customer reports a Scout policy finding. Captures how #71/#72, #74, #76, #77, #78 were fixed. Examples: 'fix the fixable HIGH CVE in build-go-alpine', 'service-base-alpine dropped below grade A', 'clear the x/sys CVE in the go tools'."
 ---
 
 # Fix a Docker Scout finding on a build image
@@ -37,7 +37,7 @@ you policy findings; `cves` tells you CVE findings. **Sections are NOT mutually
 exclusive:** F (republish a strictly-better rebuild) can and should run *alongside*
 a PR from A–C — ship the posture gain now, land the deeper fix on review.
 
-**Remediation SLA — [.github/scout-sla.json](../../../.github/scout-sla.json), per Allianz:**
+**Remediation SLA — [.github/scout-sla.json](../../../.github/scout-sla.json), per the customer:**
 a **fixable Critical** must reach a *published* fix within **15 days**, a **fixable
 High** within **30 days**, counted from when the `scout-drift` issue opened (its
 `sla:critical`/`sla:high` and `sla:at-risk`/`sla:breached` labels track the clock,

--- a/.github/scout-sla.json
+++ b/.github/scout-sla.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Remediation SLA for FIXABLE Critical/High CVEs on the required grade-A images, per the Allianz security request (2026-06): fixable Critical within 15 days, fixable High within 30 days, measured from first detection (the scout-drift issue's creation) to a published fix. Unfixable CVEs are exempt ('where fixes are available') — the continuous rebuild keeps them on the latest patches and the drift issue is the communication. Consumed by scout-drift.yml (severity classification + deadline escalation); documented in README 'Image security policies' and CLAUDE.md.",
+  "_comment": "Remediation SLA for FIXABLE Critical/High CVEs on the required grade-A images, per a customer security request (2026-06): fixable Critical within 15 days, fixable High within 30 days, measured from first detection (the scout-drift issue's creation) to a published fix. Unfixable CVEs are exempt ('where fixes are available') — the continuous rebuild keeps them on the latest patches and the drift issue is the communication. Consumed by scout-drift.yml (severity classification + deadline escalation); documented in README 'Image security policies' and CLAUDE.md.",
   "critical_days": 15,
   "high_days": 30,
   "escalate_buffer_days": 7,

--- a/.github/workflows/scout-autofix.yml
+++ b/.github/workflows/scout-autofix.yml
@@ -10,7 +10,7 @@ name: Scout autofix
 #   * opens a PR for any fix needing a NEW source change (human merges within the
 #     SLA; the next daily cycle then ships it as a patch release).
 #   * comments when the only findings are unfixable.
-# The Allianz remediation SLA (15d fixable Critical / 30d High) lives in
+# The customer remediation SLA (15d fixable Critical / 30d High) lives in
 # .github/scout-sla.json and is tracked + escalated by scout-drift.yml.
 #
 # Fences: branch protection means a PR can only be PROPOSED (a human merges);
@@ -70,7 +70,7 @@ jobs:
             /scout-fix
             The daily "Scout drift watch" failed. Read the open `scout-drift` issue —
             note any `sla:critical` / `sla:high` / `sla:at-risk` / `sla:breached`
-            labels: those carry the Allianz remediation deadline (.github/scout-sla.json
+            labels: those carry the customer remediation deadline (.github/scout-sla.json
             — 15 days for a fixable Critical, 30 for a High). Reproduce with
             `docker scout` and remediate per the skill, in this priority order:
 

--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -7,7 +7,7 @@ name: Scout drift watch
 # Scout policy grade on the published `:latest` images, opens/refreshes a tracking
 # issue + reds the run on drift, and auto-closes it on recovery.
 #
-# It also enforces the Allianz remediation SLA (.github/scout-sla.json): it
+# It also enforces the customer remediation SLA (.github/scout-sla.json): it
 # classifies the WORST fixable severity (Critical/High) behind the drift, labels
 # the issue, and ESCALATES (sla:at-risk / sla:breached + a comment) as the
 # 15-day (Critical) / 30-day (High) deadline approaches — so a fixable finding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ in CI three ways:
 | release (tag) | `publish.yml` → `scout-policy` | `docker scout policy --exit-code` (true grade) + attestations. **Hard for human-cut releases; report-only for automation's interim patch releases** (`release-meta` detects `claude[bot]`) |
 | daily cron | `scout-drift.yml` | re-scan published `:latest`; open/refresh a `scout-drift` issue on drift, auto-close on recovery, and **escalate the remediation SLA** |
 
-**Remediation SLA (Allianz — [`.github/scout-sla.json`](.github/scout-sla.json)):**
+**Remediation SLA (customer — [`.github/scout-sla.json`](.github/scout-sla.json)):**
 fixable **Critical → published fix within 15 days**, fixable **High → 30 days**;
 unfixable CVEs are exempt ("where fixes are available") but kept on the latest
 patches. The daily drift watch labels the issue (`sla:critical`/`sla:high`) and
@@ -118,5 +118,5 @@ start of a task and follow the matching skill exactly.
 
 | Skill | When to use |
 |---|---|
-| `/scout-fix` | A Docker Scout CVE or policy finding on a build image needs fixing (CI gate red, drift issue, or a customer/Allianz report) |
+| `/scout-fix` | A Docker Scout CVE or policy finding on a build image needs fixing (CI gate red, drift issue, or a customer report) |
 | `/verify-scout` | Before opening a PR that touches an image — confirm the grade-A images are still clean locally |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ one-shot apply command are in
 ### Remediation SLA & continuous improvement
 
 We commit to remediating **fixable** CVEs on the required images within a fixed
-window (per the Allianz security request), tracked in
+window (per a customer security request), tracked in
 [`.github/scout-required-images.json`](.github/scout-required-images.json)'s sibling
 [`.github/scout-sla.json`](.github/scout-sla.json):
 


### PR DESCRIPTION
## What

Removes a named customer from the remediation-SLA references — it's sensitive customer info and this is a public repo. Replaces the name with a generic "customer" across 6 files:

- `.github/scout-sla.json` (config `_comment`)
- `.github/workflows/scout-drift.yml`, `.github/workflows/scout-autofix.yml` (comments)
- `README.md`, `CLAUDE.md` (SLA prose)
- `.claude/skills/scout-fix/SKILL.md` (description + SLA note)

## Notes

- **Comments/docs only — no behavior change.** The SLA values (15d Critical / 30d High) and all logic are unchanged.
- The PR #86 *description* was already edited to remove the name.
- **History caveat:** the merged #86 commit message and git history still contain the name. Scrubbing those requires a history rewrite on protected `main` (force-push) — left as a separate decision; flagging rather than doing it unilaterally.
- Published release notes / tags may also reference it (checking the just-cut release separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY)_