### PR TITLE
ci(scout): harden release gates against Scout post-push raciness + VEX gap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,17 +115,22 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Configure DockerHub
         uses: ./.github/actions/configure-dockerhub
-      - name: Scan published image with Docker Scout (fail on HIGH/CRITICAL)
-        uses: docker/scout-action@v1
-        with:
-          command: cves
-          image: luthersystems/${{ matrix.image }}:${{ github.ref_name }}
-          only-severities: critical,high
-          only-fixed: true
-          exit-code: true
-          write-comment: false
-          dockerhub-user: ${{ env.DOCKERHUB_USERNAME }}
-          dockerhub-password: ${{ env.DOCKERHUB_TOKEN }}
+      - name: Install Docker Scout CLI
+        run: curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
+      # VEX-aware release CVE gate -- mirrors the PR-time gate in build.yml.
+      # The previous raw `docker/scout-action cves --exit-code` could NOT honor
+      # OpenVEX, so once Scout analyzed the pushed image it re-flagged
+      # build-godynamic's waived CVE-2026-34040 at release time even though the
+      # PR gate passed it (run 28482425988, attempt 2). Reuse the same
+      # scripts/scout-cve-gate.sh so the release and PR gates agree: it lists
+      # fixable CRITICAL/HIGH findings and drops only those waived by an OpenVEX
+      # not_affected statement under .github/vex/ (fail-closed on any scan/parse
+      # error). Auth via the Configure DockerHub step above plus the Scout env.
+      - name: VEX-aware CVE gate on published image (${{ matrix.image }})
+        env:
+          DOCKER_SCOUT_HUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
+          DOCKER_SCOUT_HUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: bash scripts/scout-cve-gate.sh "luthersystems/${{ matrix.image }}:${{ github.ref_name }}" "${{ matrix.image }}"
 
   # Release-time TRUE grade-A gate. The Docker Scout health grade (A–F) and its
   # supply-chain-attestation / approved+up-to-date base-image / high-profile-CVE
@@ -186,6 +191,7 @@ jobs:
             docker scout attestation add \
               --file "$f" \
               --predicate-type https://openvex.dev/ns/v0.2.0 \
+              --org luthersystems \
               --referrer \
               "luthersystems/${IMAGE}:${REF}"
           done
@@ -195,10 +201,38 @@ jobs:
           DOCKER_SCOUT_HUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
           DOCKER_SCOUT_HUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          set -euo pipefail
-          docker scout policy luthersystems/${{ matrix.image }}:${{ github.ref_name }} \
-            --org luthersystems \
-            --exit-code
+          set -uo pipefail
+          ref="luthersystems/${{ matrix.image }}:${{ github.ref_name }}"
+          # Docker Scout analyzes a pushed image asynchronously, so right after
+          # push the policy evaluation for a freshly-pushed tag may not exist yet
+          # ("No policy evaluation results found"). That is a transient race, not
+          # a grade failure -- on run 28482425988 build-go PASSED on attempt 1 and
+          # hit this on attempt 2. Poll until results appear, then let --exit-code
+          # decide. A real policy violation exits non-zero WITHOUT the "no results"
+          # marker, so it still fails fast (never waits the full window).
+          deadline=$(( SECONDS + 900 ))   # give Scout up to ~15 min to analyze
+          attempt=0
+          while :; do
+            attempt=$(( attempt + 1 ))
+            rc=0
+            out="$(docker scout policy "$ref" --org luthersystems --exit-code 2>&1)" || rc=$?
+            printf '%s\n' "$out"
+            if [ "$rc" -eq 0 ]; then
+              echo "Policy PASS for $ref (attempt $attempt)."
+              exit 0
+            fi
+            if printf '%s' "$out" | grep -qiE 'no policy .*results'; then
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "::error::Scout policy results for $ref never became available (~15 min). Re-run this job."
+                exit 1
+              fi
+              echo "Policy results not ready for $ref (attempt $attempt); retrying in 30s..."
+              sleep 30
+              continue
+            fi
+            echo "::error::Docker Scout policy is non-compliant for $ref."
+            exit "$rc"
+          done
 
   # Gate the release on supply-chain attestations actually being present on the
   # PUBLISHED multi-arch image. The Makefile attaches SBOM + provenance during

--- a/docs/upstream-cve-backlog.md
+++ b/docs/upstream-cve-backlog.md
@@ -174,13 +174,25 @@ the six packages at the `npm i -g newman` step.
   on build-js / build-swaggercodegen (build-e2e keeps root by design); only
   build-e2e would also need its non-root block restored on promotion.
 
-> Note (release gate): `publish.yml` evaluates `docker scout policy` on the
-> PUSHED image. `policy` has **no** `--vex-location` flag, so the OpenVEX doc is
-> attached to the image as an attestation
-> (`docker scout attestation add --predicate-type https://openvex.dev/ns/v0.2.0
-> --referrer`) in the scout-policy job **before** evaluation — that is how policy
-> honors a waiver server-side. The attach step is best-effort and **validated at
-> the next release**; if it can't attach (registry referrer / containerd-store
-> limits), a human release falls back to the policy escape hatch
-> (`--only-policy` / temporary `continue-on-error`) or a Docker Scout dashboard
-> exception.
+> Note (release gate — hardened after v0.1.7, run 28482425988). `publish.yml`
+> gates the PUSHED image two ways, both now consistent with the PR gate:
+>
+> - **`cve-scan`** runs the same VEX-aware `scripts/scout-cve-gate.sh` as the PR
+>   gate. It previously used raw `docker/scout-action cves --exit-code`, which
+>   cannot honor VEX, so once Scout analyzed the pushed image it re-flagged
+>   build-godynamic's waived CVE-2026-34040 at release time even though the PR
+>   gate passed it.
+> - **`scout-policy`** runs `docker scout policy`. Since `policy` has **no**
+>   `--vex-location` flag, the OpenVEX doc is first attached as an image
+>   attestation (`docker scout attestation add --predicate-type
+>   https://openvex.dev/ns/v0.2.0 --org luthersystems --referrer`) — the `--org`
+>   is mandatory (v0.1.7's attach failed with "namespace of the docker
+>   organization is mandatory"). The policy step then **polls** for results:
+>   Scout analyzes a freshly-pushed tag asynchronously and returns "No policy
+>   evaluation results found" during the race window (v0.1.7: build-go passed on
+>   attempt 1 and hit this on attempt 2), so the gate retries until results
+>   appear. A real policy violation still fails fast.
+>
+> Escape hatch if an unfixable CVE or a new low-weight policy ever blocks an
+> otherwise-good release: scope with `--only-policy`, temporarily set
+> `continue-on-error: true`, or add a Docker Scout dashboard exception.


### PR DESCRIPTION
## What

The v0.1.7 release run went red at the post-push grade gate even though every image published successfully. This hardens `publish.yml` so the next release is deterministic. **Gate robustness only — no image or release behavior change, and this does not cut a release.**

## Root cause (proven)

Re-running v0.1.7's failed jobs failed a *different, larger* set (2 → 5 jobs; `build-go` flipped pass→fail across identical attempts), which pinned three issues:

1. Docker Scout analyzes a freshly-pushed tag asynchronously, so `scout-policy` races it and intermittently returns "No policy evaluation results found" — a transient race, not a grade failure.
2. The release `cve-scan` job still used raw `docker/scout-action cves`, which cannot honor OpenVEX, so once Scout analyzed `build-godynamic` it deterministically re-flagged the VEX-waived CVE-2026-34040 — even though the PR gate (`scripts/scout-cve-gate.sh`) passes it.
3. The OpenVEX attestation-attach step lacked `--org luthersystems` and failed with "namespace of the docker organization is mandatory", so the waiver never attached for `docker scout policy` to honor.

## Changes (`publish.yml`)

- `scout-policy`: poll `docker scout policy` until results appear (up to ~15 min), then let `--exit-code` decide. A real violation (non-zero *without* the "no results" marker) still fails fast — it never waits the window.
- `cve-scan`: install the Scout CLI and run the same VEX-aware `scripts/scout-cve-gate.sh` as the PR gate, so release and PR agree.
- attestation add: pass `--org luthersystems`.
- `docs/upstream-cve-backlog.md`: record the finding + fixes.

## Testing

- Polling control flow smoke-tested with a mock `docker scout` across all three paths: retry→pass, real-violation→fail-fast, timeout→fail.
- `bash -n` + YAML parse clean; `scripts/scout-cve-gate.sh` is unchanged (already unit-smoke-tested at PR time).
- Full end-to-end validation is only possible at an actual release (these gates run against a pushed image) — this is the first fix cycle for the release-time VEX path.

## Notes

- v0.1.7's own run can't be made green (its frozen workflow isn't VEX-aware on `cve-scan`); its **published images are unaffected**. This makes the *next* release deterministic.
- Scoped intentionally to the release gate — kept separate from the in-flight docs PR so each reviews cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY)_