### PR TITLE
ci(slack): SLA lifecycle alerts to #alert, scripts-first (no-op until secret set)

### DIFF
--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -137,103 +137,48 @@ jobs:
           echo "drift=${drift}" >> "$GITHUB_OUTPUT"
           echo "worst_severity=${worst}" >> "$GITHUB_OUTPUT"
           echo "----- summary -----"; cat summary.md
+      # Issue/SLA state machine + Slack #alert egress live in
+      # scripts/scout-drift-sla.cjs (logic stays out of workflow YAML). Slack
+      # alerts for the drift/SLA lifecycle are posted INLINE from this watch —
+      # not from an issues:-triggered workflow — because this issue is created
+      # with the default GITHUB_TOKEN, whose events do NOT trigger other
+      # workflows (GitHub's anti-recursion guard). Best-effort egress: no-op
+      # until SLACK_ALERT_WEBHOOK_URL is set; a Slack outage never fails the
+      # watch (the issue + labels remain the durable SLA record).
       - name: Open/refresh the drift issue + enforce the remediation SLA
         if: steps.scan.outputs.drift == '1'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           WORST_SEVERITY: ${{ steps.scan.outputs.worst_severity }}
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
         with:
           script: |
-            const fs = require('fs');
-            const sla = JSON.parse(fs.readFileSync('.github/scout-sla.json', 'utf8'));
-            const worst = process.env.WORST_SEVERITY; // 'critical' | 'high' | 'none'
-            const body = fs.readFileSync('summary.md', 'utf8');
-            const title = 'Docker Scout: published image(s) dropped below grade A';
-            const { owner, repo } = context.repo;
-
-            const ensureLabel = async (name, color, description) => {
-              try { await github.rest.issues.createLabel({ owner, repo, name, color, description }); }
-              catch (e) { /* already exists */ }
-            };
-            await ensureLabel('scout-drift', 'b60205', 'A published image fell below Docker Scout grade A');
-            await ensureLabel('sla:critical', 'b60205', 'Fixable Critical CVE — 15-day remediation SLA');
-            await ensureLabel('sla:high', 'd93f0b', 'Fixable High CVE — 30-day remediation SLA');
-            await ensureLabel('sla:at-risk', 'fbca04', 'Remediation SLA deadline approaching');
-            await ensureLabel('sla:breached', '000000', 'Remediation SLA deadline passed');
-
-            // Open or refresh the single open scout-drift issue.
-            const open = await github.rest.issues.listForRepo({
-              owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
-            });
-            let issue;
-            if (open.data.length) {
-              issue = open.data[0];
-              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
-              core.info(`Refreshed existing issue #${issue.number}`);
-            } else {
-              issue = (await github.rest.issues.create({ owner, repo, title, body, labels: ['scout-drift'] })).data;
-              core.info(`Opened issue #${issue.number}`);
-            }
-
-            const labelsNow = new Set((issue.labels || []).map(l => (typeof l === 'string' ? l : l.name)));
-
-            // No fixable Critical/High behind the drift (e.g. a stale-base-digest
-            // policy only): no CVE SLA clock — the autonomous republish handles it.
-            if (worst !== 'critical' && worst !== 'high') {
-              core.info(`Worst fixable severity = ${worst}; no CVE SLA clock.`);
-              return;
-            }
-
-            const sevLabel = worst === 'critical' ? 'sla:critical' : 'sla:high';
-            if (!labelsNow.has(sevLabel)) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [sevLabel] });
-            }
-
-            const deadlineDays = worst === 'critical' ? sla.critical_days : sla.high_days;
-            const buffer = sla.escalate_buffer_days;
-            const ageDays = (Date.now() - new Date(issue.created_at).getTime()) / 86400000;
-            const remaining = deadlineDays - ageDays;
-            const age = Math.floor(ageDays);
-
-            if (ageDays >= deadlineDays && !labelsNow.has('sla:breached')) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['sla:breached'] });
-              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number,
-                body: `🚨 **SLA BREACHED** — this fixable **${worst}** finding has been open ${age} days, past the ${deadlineDays}-day remediation deadline (.github/scout-sla.json). Remediate and ship a release now.` });
-              core.setFailed(`SLA breached on #${issue.number} (${worst}, ${age}d > ${deadlineDays}d)`);
-            } else if (remaining <= buffer && !labelsNow.has('sla:at-risk') && !labelsNow.has('sla:breached')) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['sla:at-risk'] });
-              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number,
-                body: `⏰ **SLA at risk** — fixable **${worst}** finding open ${age} days; **${Math.ceil(remaining)} day(s) left** of the ${deadlineDays}-day deadline. Approve/merge the fix PR (or cut the release) to stay compliant.` });
-              core.warning(`SLA at risk on #${issue.number} (${worst}, ${Math.ceil(remaining)}d left)`);
-            } else {
-              core.info(`SLA ok on #${issue.number} (${worst}, ${age}d of ${deadlineDays}d)`);
-            }
+            const run = require('./scripts/scout-drift-sla.cjs');
+            await run({ github, context, core });
       - name: Close the drift issue on recovery
-        # When a scan comes back fully clean, auto-close any open scout-drift
-        # issue so the loop self-resets: drift opens it (above), recovery closes
-        # it here. `drift == '0'` means every required image is back at grade A.
+        # Fully clean scan (drift == '0') → auto-close any open scout-drift
+        # issue so the loop self-resets, and post the ✅ all-clear to Slack.
+        # Logic in scripts/scout-drift-recovery.cjs.
         if: steps.scan.outputs.drift == '0'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
         with:
           script: |
-            const { owner, repo } = context.repo;
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const open = await github.rest.issues.listForRepo({
-              owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
-            });
-            if (!open.data.length) { core.info('No open scout-drift issue to close.'); return; }
-            for (const issue of open.data) {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: issue.number,
-                body: `✅ All required images are back at Docker Scout grade A as of the latest \`Scout drift watch\` ([run](${runUrl})). Auto-closing.`,
-              });
-              await github.rest.issues.update({
-                owner, repo, issue_number: issue.number, state: 'closed', state_reason: 'completed',
-              });
-              core.info(`Closed recovered scout-drift issue #${issue.number}`);
-            }
+            const run = require('./scripts/scout-drift-recovery.cjs');
+            await run({ github, context, core });
       - name: Fail the run if drift detected
         if: steps.scan.outputs.drift == '1'
         run: |
           echo "::error::One or more published images dropped below Docker Scout grade A — see the 'scout-drift' issue."
           exit 1
+      # Silence must never look green: if the watch ITSELF errored (scan crash,
+      # API failure — yesterday's #90 class), say so in Slack. Excludes the
+      # deliberate drift failure right above (drift == '1'), which already
+      # alerted with full context from the SLA step.
+      - name: Alert Slack if the watch itself errored
+        if: failure() && steps.scan.outputs.drift != '1'
+        env:
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
+        run: |
+          bash scripts/slack-alert.sh "⚠️ *Scout drift watch errored* — the watch itself broke (no drift verdict; silence is not green). <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/slack-alerts.yml
+++ b/.github/workflows/slack-alerts.yml
@@ -1,0 +1,72 @@
+name: Slack alerts (SLA review path)
+
+# Deterministic Slack #alert egress for the SLA-lifecycle events that happen
+# OUTSIDE the drift watch: automation opening a fix PR (human review is the
+# SLA critical path), automation filing a needs-human issue (the #90 class),
+# and automation publishing an interim patch release.
+#
+# Split rationale: the drift/SLA-clock alerts are posted inline by
+# scout-drift.yml because its issue is created with the default GITHUB_TOKEN,
+# whose events do NOT trigger workflows (GitHub's anti-recursion guard) — an
+# event-driven alerter would silently miss them. THESE events are authored by
+# the Claude GitHub App token, which does trigger workflows, so a small
+# event-driven notifier is reliable here.
+#
+# All transport logic lives in scripts/slack-alert.sh (no-op until the
+# SLACK_ALERT_WEBHOOK_URL secret is set; never fails). This workflow only
+# selects event data into a message.
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issues:
+    types: [opened]
+  release:
+    types: [published]
+
+permissions:
+  contents: read # checkout only (for scripts/slack-alert.sh)
+
+jobs:
+  notify:
+    name: Notify #alert (automation events)
+    # Automation-authored events only — humans already know what they just did.
+    # Matches the Claude GitHub App ('claude' / 'claude[bot]').
+    if: startsWith(github.actor, 'claude')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Compose + send the alert
+        env:
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
+          # Event data flows via env (not inline interpolation into the shell
+          # body) so titles containing quotes/backticks can't inject; JSON
+          # escaping happens in slack-alert.sh via jq.
+          EVENT: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          REL_URL: ${{ github.event.release.html_url }}
+          REL_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -uo pipefail
+          case "$EVENT" in
+            pull_request)
+              if [ "${PR_DRAFT}" = "true" ]; then
+                echo "draft PR; alerting on ready_for_review instead"; exit 0
+              fi
+              text="🟡 *Fix PR awaiting your review* — <${PR_URL}|${PR_TITLE}> (by ${ACTOR}). Human review is the SLA critical path."
+              ;;
+            issues)
+              text="🟠 *Automation needs a human* — <${ISSUE_URL}|${ISSUE_TITLE}> (by ${ACTOR})."
+              ;;
+            release)
+              text="ℹ️ Automation published <${REL_URL}|${REL_TAG}> — interim patch release (report-only grade gate; the daily drift watch + SLA enforce)."
+              ;;
+            *)
+              echo "unhandled event: $EVENT"; exit 0
+              ;;
+          esac
+          bash scripts/slack-alert.sh "$text"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,18 @@ deadline nears. The autonomous loop ships rebuild-fixable improvements
 and auto-ships a merged source fix on the next daily cycle, so the binding
 constraint is human PR-review latency, not release cadence.
 
+**Slack alerting (SLA lifecycle → #alert):** every SLA transition (drift
+detected, clock started, at-risk, breached + daily countdown, recovery,
+watch-errored) and every automation-authored review request (fix PR /
+needs-human issue / interim release) posts to the Slack #alert channel.
+Transport is `scripts/slack-alert.sh` (`SLACK_ALERT_WEBHOOK_URL` secret;
+everything **no-ops if unset**; delivery is best-effort and never fails a
+watch — the GitHub issue + labels stay the durable SLA record). Drift/SLA
+alerts are emitted inline by `scout-drift.yml` (its issue is created with the
+default `GITHUB_TOKEN`, whose events can't trigger workflows); Claude-App-
+authored events go through `slack-alerts.yml`. Verify wiring with
+`make slack-test`.
+
 **When a Scout finding (CVE or policy) needs fixing, follow the `/scout-fix`
 skill — it captures exactly how #71/#72, #74, #76, #77, #78 were resolved, plus
 the strictly-better republish (section F) and the SLA.** Verify with
@@ -110,6 +122,13 @@ the strictly-better republish (section F) and the SLA.** Verify with
    non-root migration was the last one), not routine maintenance. Prefer the
    minimal patch/minor bump; escalate a major/contract-changing bump for review.
 4. **Pin GitHub Actions to SHAs** (Dependabot `actions` group keeps them current).
+5. **Keep logic out of workflow YAML.** Non-trivial logic goes in `scripts/`
+   (`*.sh`, or `*.cjs` loaded by `actions/github-script` via
+   `require('./scripts/<name>.cjs')`) where it can be linted, unit-tested, and
+   run standalone; workflow steps stay thin shims. Operator-relevant scripts
+   also get a root `Makefile` target (e.g. `make slack-test`). Precedents:
+   `scripts/scout-cve-gate.sh`, `scripts/scout-drift-sla.cjs`,
+   `scripts/slack-alert.sh`.
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# Root operator entry points — thin wrappers over scripts/ so repo logic is
+# callable from make (image builds stay in images/Makefile: `cd images && make …`).
+
+.PHONY: slack-test next-patch-version
+
+# Send a test alert through scripts/slack-alert.sh to verify the Slack #alert
+# webhook wiring end-to-end. No-op (prints a skip) if SLACK_ALERT_WEBHOOK_URL
+# is unset — set it from 1Password when testing locally; in CI it comes from
+# the repo secret of the same name.
+slack-test:
+	bash scripts/slack-alert.sh "🔔 Test alert from buildenv (make slack-test, $$(whoami)) — SLACK_ALERT_WEBHOOK_URL wiring OK."
+
+# Print the next patch release version (see scripts/next-patch-version.sh).
+next-patch-version:
+	bash scripts/next-patch-version.sh

--- a/scripts/scout-drift-recovery.cjs
+++ b/scripts/scout-drift-recovery.cjs
@@ -1,0 +1,46 @@
+// Auto-close recovered scout-drift issues (the drift watch's recovery path).
+//
+// Extracted from .github/workflows/scout-drift.yml so the logic lives in a
+// real file and the workflow step is a thin shim:
+//
+//   uses: actions/github-script@<pin>
+//   with:
+//     script: |
+//       const run = require('./scripts/scout-drift-recovery.cjs');
+//       await run({ github, context, core });
+//
+// Runs when the daily scan came back fully clean (drift == '0'): closes any
+// open `scout-drift` issue so the loop self-resets (drift opens it, recovery
+// closes it), and posts the ✅ all-clear to Slack #alert (best-effort via
+// scripts/slack-alert.sh; no-op without SLACK_ALERT_WEBHOOK_URL).
+'use strict';
+
+const { execFileSync } = require('child_process');
+
+const slack = (core, text) => {
+  try {
+    execFileSync('bash', ['scripts/slack-alert.sh', text], { stdio: 'inherit' });
+  } catch (e) {
+    core.warning(`slack-alert.sh failed: ${e}`);
+  }
+};
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+  const open = await github.rest.issues.listForRepo({
+    owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
+  });
+  if (!open.data.length) { core.info('No open scout-drift issue to close.'); return; }
+  for (const issue of open.data) {
+    await github.rest.issues.createComment({
+      owner, repo, issue_number: issue.number,
+      body: `✅ All required images are back at Docker Scout grade A as of the latest \`Scout drift watch\` ([run](${runUrl})). Auto-closing.`,
+    });
+    await github.rest.issues.update({
+      owner, repo, issue_number: issue.number, state: 'closed', state_reason: 'completed',
+    });
+    slack(core, `✅ *Scout drift resolved* — all required images back at grade A; auto-closed <${issue.html_url}|#${issue.number}>.`);
+    core.info(`Closed recovered scout-drift issue #${issue.number}`);
+  }
+};

--- a/scripts/scout-drift-sla.cjs
+++ b/scripts/scout-drift-sla.cjs
@@ -1,0 +1,133 @@
+// Drift-issue + remediation-SLA state machine for the daily Scout drift watch.
+//
+// Extracted from .github/workflows/scout-drift.yml so the logic lives in a
+// real, lintable, unit-testable file and the workflow step is a thin shim:
+//
+//   uses: actions/github-script@<pin>
+//   with:
+//     script: |
+//       const run = require('./scripts/scout-drift-sla.cjs');
+//       await run({ github, context, core });
+//
+// Inputs (env):
+//   WORST_SEVERITY            'critical' | 'high' | 'none'  (from the scan step)
+//   SLACK_ALERT_WEBHOOK_URL   optional — consumed by scripts/slack-alert.sh
+// Inputs (files, repo root): summary.md (scan report), .github/scout-sla.json
+//
+// What it does (unchanged semantics from the in-YAML version, #86):
+//   - opens or refreshes the single open `scout-drift` issue with the scan body
+//   - starts the SLA clock (sla:critical / sla:high label) when fixable C/H
+//     findings appear; escalates sla:at-risk → sla:breached per scout-sla.json
+//     (clock measured from issue creation; breach also fails the run)
+// New: posts Slack #alert messages at each lifecycle transition, plus a daily
+// countdown while a clock is running. Slack alerts are posted INLINE from the
+// watch (not an issues:-triggered workflow) because this issue is created with
+// the default GITHUB_TOKEN, whose events do NOT trigger other workflows
+// (GitHub's anti-recursion guard) — an event-driven alerter would silently
+// miss the main event. Delivery is best-effort via scripts/slack-alert.sh
+// (no-op without the secret, never throws): the issue + labels stay the
+// durable SLA record; Slack is egress only.
+'use strict';
+
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+
+// Single Slack transport: scripts/slack-alert.sh (handles the unset-secret
+// no-op, JSON escaping, timeouts, and never exits non-zero).
+const slack = (core, text) => {
+  try {
+    execFileSync('bash', ['scripts/slack-alert.sh', text], { stdio: 'inherit' });
+  } catch (e) {
+    core.warning(`slack-alert.sh failed: ${e}`);
+  }
+};
+
+module.exports = async ({ github, context, core }) => {
+  const sla = JSON.parse(fs.readFileSync('.github/scout-sla.json', 'utf8'));
+  const worst = process.env.WORST_SEVERITY; // 'critical' | 'high' | 'none'
+  const body = fs.readFileSync('summary.md', 'utf8');
+  const title = 'Docker Scout: published image(s) dropped below grade A';
+  const { owner, repo } = context.repo;
+
+  const ensureLabel = async (name, color, description) => {
+    try { await github.rest.issues.createLabel({ owner, repo, name, color, description }); }
+    catch (e) { /* already exists */ }
+  };
+  await ensureLabel('scout-drift', 'b60205', 'A published image fell below Docker Scout grade A');
+  await ensureLabel('sla:critical', 'b60205', 'Fixable Critical CVE — 15-day remediation SLA');
+  await ensureLabel('sla:high', 'd93f0b', 'Fixable High CVE — 30-day remediation SLA');
+  await ensureLabel('sla:at-risk', 'fbca04', 'Remediation SLA deadline approaching');
+  await ensureLabel('sla:breached', '000000', 'Remediation SLA deadline passed');
+
+  // Open or refresh the single open scout-drift issue.
+  const open = await github.rest.issues.listForRepo({
+    owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
+  });
+  let issue;
+  const isNew = !open.data.length;
+  if (!isNew) {
+    issue = open.data[0];
+    await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
+    core.info(`Refreshed existing issue #${issue.number}`);
+  } else {
+    issue = (await github.rest.issues.create({ owner, repo, title, body, labels: ['scout-drift'] })).data;
+    core.info(`Opened issue #${issue.number}`);
+  }
+  const issueRef = `<${issue.html_url}|#${issue.number}>`;
+
+  const labelsNow = new Set((issue.labels || []).map(l => (typeof l === 'string' ? l : l.name)));
+
+  // No fixable Critical/High behind the drift (e.g. a stale-base-digest policy
+  // only): no CVE SLA clock — the autonomous republish handles it. Alert once
+  // when the issue opens; daily refreshes stay GitHub-only so a lingering
+  // no-clock condition (e.g. a Scout-side evaluation gap) doesn't ping daily.
+  if (worst !== 'critical' && worst !== 'high') {
+    if (isNew) {
+      slack(core, `🟠 *Docker Scout drift* — published buildenv image(s) flagged, but no fixable Critical/High (no SLA clock; the autonomous loop handles it). ${issueRef}`);
+    }
+    core.info(`Worst fixable severity = ${worst}; no CVE SLA clock.`);
+    return;
+  }
+
+  const deadlineDays = worst === 'critical' ? sla.critical_days : sla.high_days;
+  const buffer = sla.escalate_buffer_days;
+  const ageDays = (Date.now() - new Date(issue.created_at).getTime()) / 86400000;
+  const remaining = deadlineDays - ageDays;
+  const age = Math.floor(ageDays);
+
+  // Clock start = the sla:<sev> label transition. Covers both a brand-new
+  // issue with fixable C/H and an existing no-clock issue escalating into one.
+  // (The clock is measured from issue creation, matching the label semantics.)
+  const sevLabel = worst === 'critical' ? 'sla:critical' : 'sla:high';
+  if (!labelsNow.has(sevLabel)) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [sevLabel] });
+    const due = new Date(new Date(issue.created_at).getTime() + deadlineDays * 86400000).toISOString().slice(0, 10);
+    slack(core, `🔴 *SLA clock started* — fixable *${worst.toUpperCase()}* CVE(s) on published buildenv image(s). Fix must be published by *${due}* (${deadlineDays}-day SLA). ${issueRef}`);
+  }
+
+  if (ageDays >= deadlineDays && !labelsNow.has('sla:breached')) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['sla:breached'] });
+    await github.rest.issues.createComment({ owner, repo, issue_number: issue.number,
+      body: `🚨 **SLA BREACHED** — this fixable **${worst}** finding has been open ${age} days, past the ${deadlineDays}-day remediation deadline (.github/scout-sla.json). Remediate and ship a release now.` });
+    slack(core, `<!channel> 🚨 *SLA BREACHED* — fixable *${worst}* finding open ${age}d, past the ${deadlineDays}-day deadline. Remediate and ship now. ${issueRef}`);
+    core.setFailed(`SLA breached on #${issue.number} (${worst}, ${age}d > ${deadlineDays}d)`);
+  } else if (remaining <= buffer && !labelsNow.has('sla:at-risk') && !labelsNow.has('sla:breached')) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['sla:at-risk'] });
+    await github.rest.issues.createComment({ owner, repo, issue_number: issue.number,
+      body: `⏰ **SLA at risk** — fixable **${worst}** finding open ${age} days; **${Math.ceil(remaining)} day(s) left** of the ${deadlineDays}-day deadline. Approve/merge the fix PR (or cut the release) to stay compliant.` });
+    slack(core, `<!here> ⏰ *SLA at risk* — fixable *${worst}* open ${age}d; *${Math.ceil(remaining)} day(s) left* of the ${deadlineDays}-day deadline. Approve/merge the fix PR to stay compliant. ${issueRef}`);
+    core.warning(`SLA at risk on #${issue.number} (${worst}, ${Math.ceil(remaining)}d left)`);
+  } else {
+    // Steady-state day while a clock runs: daily Slack countdown, escalating
+    // with the same thresholds the labels use. The label-transition alerts
+    // above fire once; these keep the channel current until resolution.
+    if (ageDays >= deadlineDays) {
+      slack(core, `<!channel> 🚨 *SLA breach ongoing* — fixable *${worst}* open ${age}d (deadline was ${deadlineDays}d). ${issueRef}`);
+    } else if (remaining <= buffer) {
+      slack(core, `<!here> ⏰ *SLA countdown* — fixable *${worst}*: *${Math.ceil(remaining)} day(s) left* of ${deadlineDays}. ${issueRef}`);
+    } else {
+      slack(core, `⏳ *SLA countdown* — fixable *${worst}* open ${age}d; ${Math.ceil(remaining)}d left of the ${deadlineDays}-day deadline. ${issueRef}`);
+    }
+    core.info(`SLA ok on #${issue.number} (${worst}, ${age}d of ${deadlineDays}d)`);
+  }
+};

--- a/scripts/slack-alert.sh
+++ b/scripts/slack-alert.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Post a one-line alert to the Slack #alert channel (incoming webhook).
+#
+# Usage:  slack-alert.sh "message text"      (or pipe the message on stdin)
+# Env:    SLACK_ALERT_WEBHOOK_URL — Slack incoming-webhook URL bound to the
+#         #alert channel. Unset ⇒ NO-OP (exit 0), so callers can wire alerting
+#         before the webhook/secret exists and nothing breaks.
+#
+# The message supports Slack mrkdwn: <https://url|label>, *bold*, `code`,
+# <!here>, <!channel>. JSON escaping is handled here via jq — callers pass
+# plain text and never build JSON.
+#
+# Contract: NEVER fails the caller (always exits 0). Alerting is best-effort
+# egress — a Slack outage must not red a security watch whose GitHub issue +
+# labels remain the durable record. Delivery failures surface as ::warning in
+# the Actions log. The webhook URL is a secret: never echoed, passed only to
+# curl.
+#
+# Manual end-to-end check once the secret exists: `make slack-test`.
+set -uo pipefail
+
+msg="${1:-}"
+if [ -z "$msg" ] && [ ! -t 0 ]; then
+  msg="$(cat)"
+fi
+if [ -z "$msg" ]; then
+  echo "::warning::slack-alert.sh called with an empty message; nothing sent" >&2
+  exit 0
+fi
+
+if [ -z "${SLACK_ALERT_WEBHOOK_URL:-}" ]; then
+  echo "slack-alert: SLACK_ALERT_WEBHOOK_URL not set; skipping. Message was: ${msg}"
+  exit 0
+fi
+
+payload="$(jq -cn --arg text "$msg" '{text: $text}')" || {
+  echo "::warning::slack-alert.sh: failed to build JSON payload; alert not sent" >&2
+  exit 0
+}
+
+if curl -sfS --max-time 10 --retry 2 -X POST \
+    -H 'Content-Type: application/json' \
+    --data "$payload" \
+    "$SLACK_ALERT_WEBHOOK_URL" >/dev/null; then
+  echo "slack-alert: sent"
+else
+  echo "::warning::slack-alert.sh: POST to Slack failed; alert not delivered. Message was: ${msg}" >&2
+fi
+exit 0


### PR DESCRIPTION
## What

Deterministic Slack **#alert** notifications for the Docker Scout remediation-SLA lifecycle — a fixable CVE, its fix awaiting your review, and every escalation get pushed to Slack instead of discovered on GitHub. Per repo preference, **all logic lives in `scripts/`** (lintable, unit-testable, `make`-callable); the workflow YAML is thin shims — `scout-drift.yml` actually net-shrinks.

## Alert events → #alert

| Event | Message |
|---|---|
| Drift detected, no fixable C/H | 🟠 once, on issue open (no SLA clock) |
| **SLA clock started** (`sla:critical`/`sla:high` transition) | 🔴 with the computed due date |
| Daily countdown while a clock runs | ⏳ → `<!here>` ⏰ inside the at-risk buffer → `<!channel>` 🚨 after breach |
| `sla:at-risk` / `sla:breached` transitions | ⏰ / 🚨 `<!channel>` (mirrors the issue comments) |
| **Fix PR awaiting review** / needs-human issue / interim release (claude[bot]) | 🟡 "human review is the SLA critical path" |
| Recovery (auto-close) | ✅ all-clear |
| The watch itself errored | ⚠️ "silence is not green" (excludes the deliberate drift-failure step) |

## Structure

- **`scripts/slack-alert.sh`** — the single Slack transport. Unset secret ⇒ no-op; jq-safe JSON; curl timeout/retry; **never fails the caller** (alerting is best-effort egress — the GitHub issue + labels stay the durable SLA record).
- **`scripts/scout-drift-sla.cjs`** — the issue/SLA state machine **extracted from the inline `github-script` YAML** (semantics unchanged from #86/#92) plus the new alert calls; loaded via `require('./scripts/…')`.
- **`scripts/scout-drift-recovery.cjs`** — recovery auto-close + ✅ alert.
- **`.github/workflows/slack-alerts.yml`** — small event notifier for claude[bot]-authored PRs/issues/releases. Split rationale: the drift issue is created with the default `GITHUB_TOKEN`, whose events **cannot trigger workflows** (GitHub anti-recursion) — so drift/SLA alerts must be emitted inline by `scout-drift.yml`; App-token events trigger workflows fine.
- **Root `Makefile`** — `make slack-test` (end-to-end webhook check), `make next-patch-version`.
- **CLAUDE.md** — documents the alerting + codifies rule 5: *keep logic out of workflow YAML; scripts/ + thin shims, make-callable*.

## Setup (after merge — until then everything no-ops cleanly)

1. Create a Slack **incoming webhook** bound to `#alert`; store the URL in 1Password.
2. Add repo secret **`SLACK_ALERT_WEBHOOK_URL`**.
3. Verify: `SLACK_ALERT_WEBHOOK_URL=… make slack-test` (or dispatch the drift watch).

## Testing

- `bash -n`, `node --check`, YAML parse, Makefile syntax.
- Transport contract against a local HTTP server: exact JSON payload (quotes/backticks/emoji), exit 0 on unset secret / unreachable host / empty message.
- State machine smoke-tested with mocked `github`/`core` across 6 scenarios (new-none, new-critical clock start, at-risk transition, breach transition + `setFailed`, post-breach daily, recovery close), with real shell-outs through `slack-alert.sh`.

## Not in this PR

The `@claude`-mention workflow (piece C) — deferred per discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY)_