### PR TITLE
ci(scout): code-driven Scout repo enrollment + daily self-heal (stacked on #94)

### DIFF
--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -137,103 +137,48 @@ jobs:
           echo "drift=${drift}" >> "$GITHUB_OUTPUT"
           echo "worst_severity=${worst}" >> "$GITHUB_OUTPUT"
           echo "----- summary -----"; cat summary.md
+      # Issue/SLA state machine + Slack #alert egress live in
+      # scripts/scout-drift-sla.cjs (logic stays out of workflow YAML). Slack
+      # alerts for the drift/SLA lifecycle are posted INLINE from this watch —
+      # not from an issues:-triggered workflow — because this issue is created
+      # with the default GITHUB_TOKEN, whose events do NOT trigger other
+      # workflows (GitHub's anti-recursion guard). Best-effort egress: no-op
+      # until SLACK_ALERT_WEBHOOK_URL is set; a Slack outage never fails the
+      # watch (the issue + labels remain the durable SLA record).
       - name: Open/refresh the drift issue + enforce the remediation SLA
         if: steps.scan.outputs.drift == '1'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           WORST_SEVERITY: ${{ steps.scan.outputs.worst_severity }}
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
         with:
           script: |
-            const fs = require('fs');
-            const sla = JSON.parse(fs.readFileSync('.github/scout-sla.json', 'utf8'));
-            const worst = process.env.WORST_SEVERITY; // 'critical' | 'high' | 'none'
-            const body = fs.readFileSync('summary.md', 'utf8');
-            const title = 'Docker Scout: published image(s) dropped below grade A';
-            const { owner, repo } = context.repo;
-
-            const ensureLabel = async (name, color, description) => {
-              try { await github.rest.issues.createLabel({ owner, repo, name, color, description }); }
-              catch (e) { /* already exists */ }
-            };
-            await ensureLabel('scout-drift', 'b60205', 'A published image fell below Docker Scout grade A');
-            await ensureLabel('sla:critical', 'b60205', 'Fixable Critical CVE — 15-day remediation SLA');
-            await ensureLabel('sla:high', 'd93f0b', 'Fixable High CVE — 30-day remediation SLA');
-            await ensureLabel('sla:at-risk', 'fbca04', 'Remediation SLA deadline approaching');
-            await ensureLabel('sla:breached', '000000', 'Remediation SLA deadline passed');
-
-            // Open or refresh the single open scout-drift issue.
-            const open = await github.rest.issues.listForRepo({
-              owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
-            });
-            let issue;
-            if (open.data.length) {
-              issue = open.data[0];
-              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
-              core.info(`Refreshed existing issue #${issue.number}`);
-            } else {
-              issue = (await github.rest.issues.create({ owner, repo, title, body, labels: ['scout-drift'] })).data;
-              core.info(`Opened issue #${issue.number}`);
-            }
-
-            const labelsNow = new Set((issue.labels || []).map(l => (typeof l === 'string' ? l : l.name)));
-
-            // No fixable Critical/High behind the drift (e.g. a stale-base-digest
-            // policy only): no CVE SLA clock — the autonomous republish handles it.
-            if (worst !== 'critical' && worst !== 'high') {
-              core.info(`Worst fixable severity = ${worst}; no CVE SLA clock.`);
-              return;
-            }
-
-            const sevLabel = worst === 'critical' ? 'sla:critical' : 'sla:high';
-            if (!labelsNow.has(sevLabel)) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [sevLabel] });
-            }
-
-            const deadlineDays = worst === 'critical' ? sla.critical_days : sla.high_days;
-            const buffer = sla.escalate_buffer_days;
-            const ageDays = (Date.now() - new Date(issue.created_at).getTime()) / 86400000;
-            const remaining = deadlineDays - ageDays;
-            const age = Math.floor(ageDays);
-
-            if (ageDays >= deadlineDays && !labelsNow.has('sla:breached')) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['sla:breached'] });
-              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number,
-                body: `🚨 **SLA BREACHED** — this fixable **${worst}** finding has been open ${age} days, past the ${deadlineDays}-day remediation deadline (.github/scout-sla.json). Remediate and ship a release now.` });
-              core.setFailed(`SLA breached on #${issue.number} (${worst}, ${age}d > ${deadlineDays}d)`);
-            } else if (remaining <= buffer && !labelsNow.has('sla:at-risk') && !labelsNow.has('sla:breached')) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['sla:at-risk'] });
-              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number,
-                body: `⏰ **SLA at risk** — fixable **${worst}** finding open ${age} days; **${Math.ceil(remaining)} day(s) left** of the ${deadlineDays}-day deadline. Approve/merge the fix PR (or cut the release) to stay compliant.` });
-              core.warning(`SLA at risk on #${issue.number} (${worst}, ${Math.ceil(remaining)}d left)`);
-            } else {
-              core.info(`SLA ok on #${issue.number} (${worst}, ${age}d of ${deadlineDays}d)`);
-            }
+            const run = require('./scripts/scout-drift-sla.cjs');
+            await run({ github, context, core });
       - name: Close the drift issue on recovery
-        # When a scan comes back fully clean, auto-close any open scout-drift
-        # issue so the loop self-resets: drift opens it (above), recovery closes
-        # it here. `drift == '0'` means every required image is back at grade A.
+        # Fully clean scan (drift == '0') → auto-close any open scout-drift
+        # issue so the loop self-resets, and post the ✅ all-clear to Slack.
+        # Logic in scripts/scout-drift-recovery.cjs.
         if: steps.scan.outputs.drift == '0'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
         with:
           script: |
-            const { owner, repo } = context.repo;
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const open = await github.rest.issues.listForRepo({
-              owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
-            });
-            if (!open.data.length) { core.info('No open scout-drift issue to close.'); return; }
-            for (const issue of open.data) {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: issue.number,
-                body: `✅ All required images are back at Docker Scout grade A as of the latest \`Scout drift watch\` ([run](${runUrl})). Auto-closing.`,
-              });
-              await github.rest.issues.update({
-                owner, repo, issue_number: issue.number, state: 'closed', state_reason: 'completed',
-              });
-              core.info(`Closed recovered scout-drift issue #${issue.number}`);
-            }
+            const run = require('./scripts/scout-drift-recovery.cjs');
+            await run({ github, context, core });
       - name: Fail the run if drift detected
         if: steps.scan.outputs.drift == '1'
         run: |
           echo "::error::One or more published images dropped below Docker Scout grade A — see the 'scout-drift' issue."
           exit 1
+      # Silence must never look green: if the watch ITSELF errored (scan crash,
+      # API failure — yesterday's #90 class), say so in Slack. Excludes the
+      # deliberate drift failure right above (drift == '1'), which already
+      # alerted with full context from the SLA step.
+      - name: Alert Slack if the watch itself errored
+        if: failure() && steps.scan.outputs.drift != '1'
+        env:
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
+        run: |
+          bash scripts/slack-alert.sh "⚠️ *Scout drift watch errored* — the watch itself broke (no drift verdict; silence is not green). <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -36,6 +36,20 @@ jobs:
         uses: ./.github/actions/configure-dockerhub
       - name: Install Docker Scout CLI
         run: curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
+      # Scout enrollment is config-drift-prone: build-go / build-java /
+      # nginx-frontend / build-godynamic were each found silently un-enrolled
+      # (July 2026), and an un-enrolled repo yields NO policy results — which
+      # the scan below then flags as ⚠️ drift. Reconcile it daily from
+      # scout-required-images.json (idempotent; alerts #alert when it had to
+      # fix something). Best-effort: an enablement API failure must not stop
+      # the scan — the scan's no-policy-results path still surfaces the
+      # symptom. Logic: scripts/scout-setup.sh (also `make scout-setup`).
+      - name: Self-heal Docker Scout repo enrollment
+        env:
+          DOCKER_SCOUT_HUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
+          DOCKER_SCOUT_HUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
+        run: bash scripts/scout-setup.sh || echo "::warning::scout-setup.sh failed; continuing to the scan"
       - name: Evaluate Scout policy + worst fixable severity on each required :latest image
         id: scan
         env:

--- a/.github/workflows/slack-alerts.yml
+++ b/.github/workflows/slack-alerts.yml
@@ -1,0 +1,72 @@
+name: Slack alerts (SLA review path)
+
+# Deterministic Slack #alert egress for the SLA-lifecycle events that happen
+# OUTSIDE the drift watch: automation opening a fix PR (human review is the
+# SLA critical path), automation filing a needs-human issue (the #90 class),
+# and automation publishing an interim patch release.
+#
+# Split rationale: the drift/SLA-clock alerts are posted inline by
+# scout-drift.yml because its issue is created with the default GITHUB_TOKEN,
+# whose events do NOT trigger workflows (GitHub's anti-recursion guard) — an
+# event-driven alerter would silently miss them. THESE events are authored by
+# the Claude GitHub App token, which does trigger workflows, so a small
+# event-driven notifier is reliable here.
+#
+# All transport logic lives in scripts/slack-alert.sh (no-op until the
+# SLACK_ALERT_WEBHOOK_URL secret is set; never fails). This workflow only
+# selects event data into a message.
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issues:
+    types: [opened]
+  release:
+    types: [published]
+
+permissions:
+  contents: read # checkout only (for scripts/slack-alert.sh)
+
+jobs:
+  notify:
+    name: Notify #alert (automation events)
+    # Automation-authored events only — humans already know what they just did.
+    # Matches the Claude GitHub App ('claude' / 'claude[bot]').
+    if: startsWith(github.actor, 'claude')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Compose + send the alert
+        env:
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
+          # Event data flows via env (not inline interpolation into the shell
+          # body) so titles containing quotes/backticks can't inject; JSON
+          # escaping happens in slack-alert.sh via jq.
+          EVENT: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          REL_URL: ${{ github.event.release.html_url }}
+          REL_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -uo pipefail
+          case "$EVENT" in
+            pull_request)
+              if [ "${PR_DRAFT}" = "true" ]; then
+                echo "draft PR; alerting on ready_for_review instead"; exit 0
+              fi
+              text="🟡 *Fix PR awaiting your review* — <${PR_URL}|${PR_TITLE}> (by ${ACTOR}). Human review is the SLA critical path."
+              ;;
+            issues)
+              text="🟠 *Automation needs a human* — <${ISSUE_URL}|${ISSUE_TITLE}> (by ${ACTOR})."
+              ;;
+            release)
+              text="ℹ️ Automation published <${REL_URL}|${REL_TAG}> — interim patch release (report-only grade gate; the daily drift watch + SLA enforce)."
+              ;;
+            *)
+              echo "unhandled event: $EVENT"; exit 0
+              ;;
+          esac
+          bash scripts/slack-alert.sh "$text"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,18 @@ deadline nears. The autonomous loop ships rebuild-fixable improvements
 and auto-ships a merged source fix on the next daily cycle, so the binding
 constraint is human PR-review latency, not release cadence.
 
+**Slack alerting (SLA lifecycle → #alert):** every SLA transition (drift
+detected, clock started, at-risk, breached + daily countdown, recovery,
+watch-errored) and every automation-authored review request (fix PR /
+needs-human issue / interim release) posts to the Slack #alert channel.
+Transport is `scripts/slack-alert.sh` (`SLACK_ALERT_WEBHOOK_URL` secret;
+everything **no-ops if unset**; delivery is best-effort and never fails a
+watch — the GitHub issue + labels stay the durable SLA record). Drift/SLA
+alerts are emitted inline by `scout-drift.yml` (its issue is created with the
+default `GITHUB_TOKEN`, whose events can't trigger workflows); Claude-App-
+authored events go through `slack-alerts.yml`. Verify wiring with
+`make slack-test`.
+
 **When a Scout finding (CVE or policy) needs fixing, follow the `/scout-fix`
 skill — it captures exactly how #71/#72, #74, #76, #77, #78 were resolved, plus
 the strictly-better republish (section F) and the SLA.** Verify with
@@ -110,6 +122,13 @@ the strictly-better republish (section F) and the SLA.** Verify with
    non-root migration was the last one), not routine maintenance. Prefer the
    minimal patch/minor bump; escalate a major/contract-changing bump for review.
 4. **Pin GitHub Actions to SHAs** (Dependabot `actions` group keeps them current).
+5. **Keep logic out of workflow YAML.** Non-trivial logic goes in `scripts/`
+   (`*.sh`, or `*.cjs` loaded by `actions/github-script` via
+   `require('./scripts/<name>.cjs')`) where it can be linted, unit-tested, and
+   run standalone; workflow steps stay thin shims. Operator-relevant scripts
+   also get a root `Makefile` target (e.g. `make slack-test`). Precedents:
+   `scripts/scout-cve-gate.sh`, `scripts/scout-drift-sla.cjs`,
+   `scripts/slack-alert.sh`.
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,16 @@ default `GITHUB_TOKEN`, whose events can't trigger workflows); Claude-App-
 authored events go through `slack-alerts.yml`. Verify wiring with
 `make slack-test`.
 
+**Scout enrollment is code-driven — never hand-toggle it in the Hub UI.**
+`scripts/scout-setup.sh` (`make scout-setup` / `make scout-check`) reconciles
+Docker Scout repo enablement with `scout-required-images.json`, and the daily
+drift watch runs it first as a self-heal (an un-enrolled repo yields NO policy
+results and silently falls out of the gates — the July 2026 failure class:
+build-go, build-java, nginx-frontend, build-godynamic were each found
+disabled). Org **policy configuration** (which policies gate, license lists,
+disabling a policy) has **no public API or CLI** — Docker Scout dashboard only
+(policy details page → Edit/Disable).
+
 **When a Scout finding (CVE or policy) needs fixing, follow the `/scout-fix`
 skill — it captures exactly how #71/#72, #74, #76, #77, #78 were resolved, plus
 the strictly-better republish (section F) and the SLA.** Verify with

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# Root operator entry points — thin wrappers over scripts/ so repo logic is
+# callable from make (image builds stay in images/Makefile: `cd images && make …`).
+
+.PHONY: slack-test next-patch-version
+
+# Send a test alert through scripts/slack-alert.sh to verify the Slack #alert
+# webhook wiring end-to-end. No-op (prints a skip) if SLACK_ALERT_WEBHOOK_URL
+# is unset — set it from 1Password when testing locally; in CI it comes from
+# the repo secret of the same name.
+slack-test:
+	bash scripts/slack-alert.sh "🔔 Test alert from buildenv (make slack-test, $$(whoami)) — SLACK_ALERT_WEBHOOK_URL wiring OK."
+
+# Print the next patch release version (see scripts/next-patch-version.sh).
+next-patch-version:
+	bash scripts/next-patch-version.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Root operator entry points — thin wrappers over scripts/ so repo logic is
 # callable from make (image builds stay in images/Makefile: `cd images && make …`).
 
-.PHONY: slack-test next-patch-version
+.PHONY: slack-test next-patch-version scout-setup scout-check
 
 # Send a test alert through scripts/slack-alert.sh to verify the Slack #alert
 # webhook wiring end-to-end. No-op (prints a skip) if SLACK_ALERT_WEBHOOK_URL
@@ -13,3 +13,12 @@ slack-test:
 # Print the next patch release version (see scripts/next-patch-version.sh).
 next-patch-version:
 	bash scripts/next-patch-version.sh
+
+# Reconcile Docker Scout repo enrollment with scout-required-images.json
+# (idempotent; needs DOCKER_SCOUT_HUB_USER/PASSWORD). scout-check is the
+# report-only variant. See scripts/scout-setup.sh.
+scout-setup:
+	bash scripts/scout-setup.sh
+
+scout-check:
+	bash scripts/scout-setup.sh --check

--- a/scripts/scout-drift-recovery.cjs
+++ b/scripts/scout-drift-recovery.cjs
@@ -1,0 +1,46 @@
+// Auto-close recovered scout-drift issues (the drift watch's recovery path).
+//
+// Extracted from .github/workflows/scout-drift.yml so the logic lives in a
+// real file and the workflow step is a thin shim:
+//
+//   uses: actions/github-script@<pin>
+//   with:
+//     script: |
+//       const run = require('./scripts/scout-drift-recovery.cjs');
+//       await run({ github, context, core });
+//
+// Runs when the daily scan came back fully clean (drift == '0'): closes any
+// open `scout-drift` issue so the loop self-resets (drift opens it, recovery
+// closes it), and posts the ✅ all-clear to Slack #alert (best-effort via
+// scripts/slack-alert.sh; no-op without SLACK_ALERT_WEBHOOK_URL).
+'use strict';
+
+const { execFileSync } = require('child_process');
+
+const slack = (core, text) => {
+  try {
+    execFileSync('bash', ['scripts/slack-alert.sh', text], { stdio: 'inherit' });
+  } catch (e) {
+    core.warning(`slack-alert.sh failed: ${e}`);
+  }
+};
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+  const open = await github.rest.issues.listForRepo({
+    owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
+  });
+  if (!open.data.length) { core.info('No open scout-drift issue to close.'); return; }
+  for (const issue of open.data) {
+    await github.rest.issues.createComment({
+      owner, repo, issue_number: issue.number,
+      body: `✅ All required images are back at Docker Scout grade A as of the latest \`Scout drift watch\` ([run](${runUrl})). Auto-closing.`,
+    });
+    await github.rest.issues.update({
+      owner, repo, issue_number: issue.number, state: 'closed', state_reason: 'completed',
+    });
+    slack(core, `✅ *Scout drift resolved* — all required images back at grade A; auto-closed <${issue.html_url}|#${issue.number}>.`);
+    core.info(`Closed recovered scout-drift issue #${issue.number}`);
+  }
+};

--- a/scripts/scout-drift-sla.cjs
+++ b/scripts/scout-drift-sla.cjs
@@ -1,0 +1,133 @@
+// Drift-issue + remediation-SLA state machine for the daily Scout drift watch.
+//
+// Extracted from .github/workflows/scout-drift.yml so the logic lives in a
+// real, lintable, unit-testable file and the workflow step is a thin shim:
+//
+//   uses: actions/github-script@<pin>
+//   with:
+//     script: |
+//       const run = require('./scripts/scout-drift-sla.cjs');
+//       await run({ github, context, core });
+//
+// Inputs (env):
+//   WORST_SEVERITY            'critical' | 'high' | 'none'  (from the scan step)
+//   SLACK_ALERT_WEBHOOK_URL   optional — consumed by scripts/slack-alert.sh
+// Inputs (files, repo root): summary.md (scan report), .github/scout-sla.json
+//
+// What it does (unchanged semantics from the in-YAML version, #86):
+//   - opens or refreshes the single open `scout-drift` issue with the scan body
+//   - starts the SLA clock (sla:critical / sla:high label) when fixable C/H
+//     findings appear; escalates sla:at-risk → sla:breached per scout-sla.json
+//     (clock measured from issue creation; breach also fails the run)
+// New: posts Slack #alert messages at each lifecycle transition, plus a daily
+// countdown while a clock is running. Slack alerts are posted INLINE from the
+// watch (not an issues:-triggered workflow) because this issue is created with
+// the default GITHUB_TOKEN, whose events do NOT trigger other workflows
+// (GitHub's anti-recursion guard) — an event-driven alerter would silently
+// miss the main event. Delivery is best-effort via scripts/slack-alert.sh
+// (no-op without the secret, never throws): the issue + labels stay the
+// durable SLA record; Slack is egress only.
+'use strict';
+
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+
+// Single Slack transport: scripts/slack-alert.sh (handles the unset-secret
+// no-op, JSON escaping, timeouts, and never exits non-zero).
+const slack = (core, text) => {
+  try {
+    execFileSync('bash', ['scripts/slack-alert.sh', text], { stdio: 'inherit' });
+  } catch (e) {
+    core.warning(`slack-alert.sh failed: ${e}`);
+  }
+};
+
+module.exports = async ({ github, context, core }) => {
+  const sla = JSON.parse(fs.readFileSync('.github/scout-sla.json', 'utf8'));
+  const worst = process.env.WORST_SEVERITY; // 'critical' | 'high' | 'none'
+  const body = fs.readFileSync('summary.md', 'utf8');
+  const title = 'Docker Scout: published image(s) dropped below grade A';
+  const { owner, repo } = context.repo;
+
+  const ensureLabel = async (name, color, description) => {
+    try { await github.rest.issues.createLabel({ owner, repo, name, color, description }); }
+    catch (e) { /* already exists */ }
+  };
+  await ensureLabel('scout-drift', 'b60205', 'A published image fell below Docker Scout grade A');
+  await ensureLabel('sla:critical', 'b60205', 'Fixable Critical CVE — 15-day remediation SLA');
+  await ensureLabel('sla:high', 'd93f0b', 'Fixable High CVE — 30-day remediation SLA');
+  await ensureLabel('sla:at-risk', 'fbca04', 'Remediation SLA deadline approaching');
+  await ensureLabel('sla:breached', '000000', 'Remediation SLA deadline passed');
+
+  // Open or refresh the single open scout-drift issue.
+  const open = await github.rest.issues.listForRepo({
+    owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
+  });
+  let issue;
+  const isNew = !open.data.length;
+  if (!isNew) {
+    issue = open.data[0];
+    await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
+    core.info(`Refreshed existing issue #${issue.number}`);
+  } else {
+    issue = (await github.rest.issues.create({ owner, repo, title, body, labels: ['scout-drift'] })).data;
+    core.info(`Opened issue #${issue.number}`);
+  }
+  const issueRef = `<${issue.html_url}|#${issue.number}>`;
+
+  const labelsNow = new Set((issue.labels || []).map(l => (typeof l === 'string' ? l : l.name)));
+
+  // No fixable Critical/High behind the drift (e.g. a stale-base-digest policy
+  // only): no CVE SLA clock — the autonomous republish handles it. Alert once
+  // when the issue opens; daily refreshes stay GitHub-only so a lingering
+  // no-clock condition (e.g. a Scout-side evaluation gap) doesn't ping daily.
+  if (worst !== 'critical' && worst !== 'high') {
+    if (isNew) {
+      slack(core, `🟠 *Docker Scout drift* — published buildenv image(s) flagged, but no fixable Critical/High (no SLA clock; the autonomous loop handles it). ${issueRef}`);
+    }
+    core.info(`Worst fixable severity = ${worst}; no CVE SLA clock.`);
+    return;
+  }
+
+  const deadlineDays = worst === 'critical' ? sla.critical_days : sla.high_days;
+  const buffer = sla.escalate_buffer_days;
+  const ageDays = (Date.now() - new Date(issue.created_at).getTime()) / 86400000;
+  const remaining = deadlineDays - ageDays;
+  const age = Math.floor(ageDays);
+
+  // Clock start = the sla:<sev> label transition. Covers both a brand-new
+  // issue with fixable C/H and an existing no-clock issue escalating into one.
+  // (The clock is measured from issue creation, matching the label semantics.)
+  const sevLabel = worst === 'critical' ? 'sla:critical' : 'sla:high';
+  if (!labelsNow.has(sevLabel)) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [sevLabel] });
+    const due = new Date(new Date(issue.created_at).getTime() + deadlineDays * 86400000).toISOString().slice(0, 10);
+    slack(core, `🔴 *SLA clock started* — fixable *${worst.toUpperCase()}* CVE(s) on published buildenv image(s). Fix must be published by *${due}* (${deadlineDays}-day SLA). ${issueRef}`);
+  }
+
+  if (ageDays >= deadlineDays && !labelsNow.has('sla:breached')) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['sla:breached'] });
+    await github.rest.issues.createComment({ owner, repo, issue_number: issue.number,
+      body: `🚨 **SLA BREACHED** — this fixable **${worst}** finding has been open ${age} days, past the ${deadlineDays}-day remediation deadline (.github/scout-sla.json). Remediate and ship a release now.` });
+    slack(core, `<!channel> 🚨 *SLA BREACHED* — fixable *${worst}* finding open ${age}d, past the ${deadlineDays}-day deadline. Remediate and ship now. ${issueRef}`);
+    core.setFailed(`SLA breached on #${issue.number} (${worst}, ${age}d > ${deadlineDays}d)`);
+  } else if (remaining <= buffer && !labelsNow.has('sla:at-risk') && !labelsNow.has('sla:breached')) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['sla:at-risk'] });
+    await github.rest.issues.createComment({ owner, repo, issue_number: issue.number,
+      body: `⏰ **SLA at risk** — fixable **${worst}** finding open ${age} days; **${Math.ceil(remaining)} day(s) left** of the ${deadlineDays}-day deadline. Approve/merge the fix PR (or cut the release) to stay compliant.` });
+    slack(core, `<!here> ⏰ *SLA at risk* — fixable *${worst}* open ${age}d; *${Math.ceil(remaining)} day(s) left* of the ${deadlineDays}-day deadline. Approve/merge the fix PR to stay compliant. ${issueRef}`);
+    core.warning(`SLA at risk on #${issue.number} (${worst}, ${Math.ceil(remaining)}d left)`);
+  } else {
+    // Steady-state day while a clock runs: daily Slack countdown, escalating
+    // with the same thresholds the labels use. The label-transition alerts
+    // above fire once; these keep the channel current until resolution.
+    if (ageDays >= deadlineDays) {
+      slack(core, `<!channel> 🚨 *SLA breach ongoing* — fixable *${worst}* open ${age}d (deadline was ${deadlineDays}d). ${issueRef}`);
+    } else if (remaining <= buffer) {
+      slack(core, `<!here> ⏰ *SLA countdown* — fixable *${worst}*: *${Math.ceil(remaining)} day(s) left* of ${deadlineDays}. ${issueRef}`);
+    } else {
+      slack(core, `⏳ *SLA countdown* — fixable *${worst}* open ${age}d; ${Math.ceil(remaining)}d left of the ${deadlineDays}-day deadline. ${issueRef}`);
+    }
+    core.info(`SLA ok on #${issue.number} (${worst}, ${age}d of ${deadlineDays}d)`);
+  }
+};

--- a/scripts/scout-setup.sh
+++ b/scripts/scout-setup.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Code-driven Docker Scout repo enrollment for the buildenv image set.
+#
+# Every incident in the July 2026 grade-gate saga traced back to hand-toggled
+# Scout enablement: build-go, build-java, nginx-frontend and build-godynamic
+# were each found silently un-enrolled, and an un-enrolled repo produces NO
+# policy evaluation results — which the gates/watch then surface as
+# "no policy results" drift. This script makes enrollment code-driven off
+# .github/scout-required-images.json (required + cve_net_extra + exempt keys),
+# so the enabled set can be reconciled programmatically instead of hunted
+# through the Hub UI.
+#
+# Usage:
+#   scout-setup.sh            enroll the org + enable Scout on every image in
+#                             the JSON (idempotent). Alerts Slack #alert (via
+#                             scripts/slack-alert.sh, if present) when it had
+#                             to fix a repo that was found disabled.
+#   scout-setup.sh --check    report-only: list desired vs currently-enabled;
+#                             exit 1 if any desired repo is not enabled,
+#                             exit 2 if enablement state cannot be determined.
+#
+# Env:
+#   DOCKER_SCOUT_HUB_USER / DOCKER_SCOUT_HUB_PASSWORD  Docker Hub creds for the
+#       scout CLI (same pair the CI gates use). Locally: export from 1Password.
+#   SCOUT_ORG   defaults to luthersystems.
+#
+# NOTE the split of what is automatable: repo ENROLLMENT has CLI support
+# (docker scout enroll / repo enable / repo list — used here). Org POLICY
+# configuration (which policies gate, license lists, disable a policy) has NO
+# public API or CLI — dashboard only (policy details page → Edit/Disable).
+#
+# Parsing fail-safe: `docker scout repo list` output is not a stable contract,
+# so if its output cannot be recognized this script does NOT guess enablement
+# state — in enable mode it falls back to enabling every desired repo
+# (idempotent, still correct, just no "what was broken" alert); in --check
+# mode it exits 2 rather than reporting a wrong answer.
+set -uo pipefail
+
+ORG="${SCOUT_ORG:-luthersystems}"
+JSON=".github/scout-required-images.json"
+MODE="${1:-enable}"
+
+if [ ! -f "$JSON" ]; then
+  echo "::error::${JSON} not found (run from the repo root)" >&2
+  exit 1
+fi
+
+# Desired set = full grade-A set + CVE-net extras + exempt (exempt images are
+# not hard-gated, but Scout coverage/analysis is still wanted on them).
+desired="$(jq -r '.required[], .cve_net_extra[], (.exempt | keys[])' "$JSON" | sort -u)"
+if [ -z "$desired" ]; then
+  echo "::error::no images parsed from ${JSON}" >&2
+  exit 1
+fi
+
+# Current enablement, best-effort. parse_ok=0 means "could not determine".
+parse_ok=0
+enabled=""
+set +e
+list_out="$(docker scout repo list --org "$ORG" 2>&1)"
+list_rc=$?
+set -e
+if [ "$list_rc" -eq 0 ] && [ -n "$list_out" ]; then
+  # Heuristic: a repo's line mentions the image name; enablement shows as
+  # 'enabled'/'true'/checkmark on the same line. Guarded by the fail-safe
+  # above — a parse miss can only cause extra idempotent enables, never a
+  # wrong "all good".
+  enabled="$(printf '%s\n' "$list_out" \
+    | grep -Ei 'enabled|true|✓' \
+    | grep -oE "(${ORG}/)?[a-z0-9][a-z0-9._-]*" \
+    | sed "s|^${ORG}/||" | sort -u || true)"
+  [ -n "$enabled" ] && parse_ok=1
+fi
+if [ "$parse_ok" -eq 0 ]; then
+  echo "::warning::could not determine current Scout enablement from 'docker scout repo list' (rc=${list_rc}); proceeding without it"
+fi
+
+missing=""
+if [ "$parse_ok" -eq 1 ]; then
+  missing="$(comm -23 <(printf '%s\n' "$desired") <(printf '%s\n' "$enabled") || true)"
+fi
+
+if [ "$MODE" = "--check" ]; then
+  echo "Desired Scout-enabled repos (${JSON}):"
+  printf '%s\n' "$desired" | sed 's/^/  - /'
+  if [ "$parse_ok" -eq 0 ]; then
+    echo "::warning::enablement state undetermined — run without --check to reconcile idempotently"
+    exit 2
+  fi
+  if [ -n "$missing" ]; then
+    echo "::error::NOT Scout-enabled:"
+    printf '%s\n' "$missing" | sed 's/^/  - /'
+    exit 1
+  fi
+  echo "All desired repos are Scout-enabled."
+  exit 0
+fi
+
+# Enable mode. Enroll the org (idempotent), then enable each target repo:
+# only the known-missing ones when we could read state (so the Slack alert
+# is precise), else all of them (idempotent fail-safe).
+targets="$missing"
+[ "$parse_ok" -eq 0 ] && targets="$desired"
+if [ -z "$targets" ]; then
+  echo "Scout enrollment OK: all $(printf '%s\n' "$desired" | wc -l | tr -d ' ') repos already enabled."
+  exit 0
+fi
+
+set +e
+docker scout enroll "$ORG" >/dev/null 2>&1
+set -e
+
+failed=""
+fixed=""
+while IFS= read -r img; do
+  [ -z "$img" ] && continue
+  set +e
+  out="$(docker scout repo enable --org "$ORG" "${ORG}/${img}" 2>&1)"
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "enabled: ${ORG}/${img}"
+    fixed="${fixed}${img}\n"
+  else
+    echo "::warning::failed to enable Scout on ${ORG}/${img} (rc=${rc}): ${out}"
+    failed="${failed}${img}\n"
+  fi
+done <<< "$targets"
+
+# Alert only on a *known* fix (state was readable and a desired repo was found
+# disabled) — that is enrollment drift worth telling #alert about.
+if [ "$parse_ok" -eq 1 ] && [ -n "$fixed" ] && [ -f scripts/slack-alert.sh ]; then
+  pretty="$(printf "$fixed" | sed '/^$/d' | paste -sd', ' -)"
+  bash scripts/slack-alert.sh "⚠️ *Scout enrollment drift* — repo(s) were disabled in Docker Scout and have been re-enabled automatically: ${pretty}. (Un-enrolled repos produce no policy results and silently fall out of the grade gates.)"
+fi
+
+if [ -n "$failed" ]; then
+  echo "::error::some repos could not be enabled (see warnings above)"
+  exit 1
+fi
+echo "Scout enrollment reconciled."

--- a/scripts/slack-alert.sh
+++ b/scripts/slack-alert.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Post a one-line alert to the Slack #alert channel (incoming webhook).
+#
+# Usage:  slack-alert.sh "message text"      (or pipe the message on stdin)
+# Env:    SLACK_ALERT_WEBHOOK_URL — Slack incoming-webhook URL bound to the
+#         #alert channel. Unset ⇒ NO-OP (exit 0), so callers can wire alerting
+#         before the webhook/secret exists and nothing breaks.
+#
+# The message supports Slack mrkdwn: <https://url|label>, *bold*, `code`,
+# <!here>, <!channel>. JSON escaping is handled here via jq — callers pass
+# plain text and never build JSON.
+#
+# Contract: NEVER fails the caller (always exits 0). Alerting is best-effort
+# egress — a Slack outage must not red a security watch whose GitHub issue +
+# labels remain the durable record. Delivery failures surface as ::warning in
+# the Actions log. The webhook URL is a secret: never echoed, passed only to
+# curl.
+#
+# Manual end-to-end check once the secret exists: `make slack-test`.
+set -uo pipefail
+
+msg="${1:-}"
+if [ -z "$msg" ] && [ ! -t 0 ]; then
+  msg="$(cat)"
+fi
+if [ -z "$msg" ]; then
+  echo "::warning::slack-alert.sh called with an empty message; nothing sent" >&2
+  exit 0
+fi
+
+if [ -z "${SLACK_ALERT_WEBHOOK_URL:-}" ]; then
+  echo "slack-alert: SLACK_ALERT_WEBHOOK_URL not set; skipping. Message was: ${msg}"
+  exit 0
+fi
+
+payload="$(jq -cn --arg text "$msg" '{text: $text}')" || {
+  echo "::warning::slack-alert.sh: failed to build JSON payload; alert not sent" >&2
+  exit 0
+}
+
+if curl -sfS --max-time 10 --retry 2 -X POST \
+    -H 'Content-Type: application/json' \
+    --data "$payload" \
+    "$SLACK_ALERT_WEBHOOK_URL" >/dev/null; then
+  echo "slack-alert: sent"
+else
+  echo "::warning::slack-alert.sh: POST to Slack failed; alert not delivered. Message was: ${msg}" >&2
+fi
+exit 0


### PR DESCRIPTION
> **Stacked on #94** — merge #94 first; this diff then shrinks to just the enrollment guard (one script + one workflow step + Makefile/CLAUDE.md lines). It reuses #94's `scripts/slack-alert.sh` transport.

## What

Makes Docker Scout **repo enrollment code-driven and self-healing**, keyed off `scout-required-images.json`. Every incident in this week's grade-gate saga traced to hand-toggled Scout enablement (build-go, build-java, nginx-frontend, build-godynamic were each found silently disabled — an un-enrolled repo yields *no policy results* and falls out of the gates with only an opaque symptom).

## How

- **`scripts/scout-setup.sh`** — reconciles Scout enablement with the JSON (all 10 images: `required` + `cve_net_extra` + `exempt` — coverage everywhere, gating stays per-workflow):
  - default mode: idempotent enable; posts a **precise** Slack #alert only when a repo was positively found disabled and re-enabled;
  - `--check`: report-only (exit 1 on a gap, exit 2 if state can't be determined);
  - **parsing fail-safe**: `docker scout repo list` output isn't a stable contract — an unrecognized listing degrades to enabling every desired repo (idempotent, still correct) rather than guessing, and never emits a false alert.
- **`scout-drift.yml`** — runs the reconcile daily *before* the scan, best-effort (an enablement-API failure warns and continues; the scan's no-policy-results path still surfaces the symptom).
- **`Makefile`** — `make scout-setup` / `make scout-check`.
- **`CLAUDE.md`** — enrollment is code-driven, never hand-toggled; documents that org **policy configuration** (which policies gate, license lists, disabling a policy) has **no public API/CLI** — Docker Scout dashboard only.

## Notes / caveats

- Uses the same Docker Hub creds the gates already use (`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`). If that token lacks permission for `docker scout repo enable`, the step degrades to warnings (never blocks the scan) — worth watching the first daily run.
- Does **not** touch the copyleft-policy situation (that's dashboard-only config; no API exists — see PR discussion in the session).

## Testing

Smoke-tested with a mock `docker` CLI across 7 paths: missing repo → enable *only* it + precise alert; all-enabled no-op; list-failure fail-safe (enables all, **no false alert**); enable-failure → exit 1; `--check` missing/clean/undetermined → 1/0/2. `bash -n`, YAML parse, `make -n` clean; the jq desired-set extraction verified against the real JSON (all 10 images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY)_