### PR TITLE
docs: #alert → #alerts channel name + gitignore agent scratch dirs

### DIFF
--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -40,7 +40,7 @@ jobs:
       # nginx-frontend / build-godynamic were each found silently un-enrolled
       # (July 2026), and an un-enrolled repo yields NO policy results — which
       # the scan below then flags as ⚠️ drift. Reconcile it daily from
-      # scout-required-images.json (idempotent; alerts #alert when it had to
+      # scout-required-images.json (idempotent; alerts #alerts when it had to
       # fix something). Best-effort: an enablement API failure must not stop
       # the scan — the scan's no-policy-results path still surfaces the
       # symptom. Logic: scripts/scout-setup.sh (also `make scout-setup`).
@@ -151,7 +151,7 @@ jobs:
           echo "drift=${drift}" >> "$GITHUB_OUTPUT"
           echo "worst_severity=${worst}" >> "$GITHUB_OUTPUT"
           echo "----- summary -----"; cat summary.md
-      # Issue/SLA state machine + Slack #alert egress live in
+      # Issue/SLA state machine + Slack #alerts egress live in
       # scripts/scout-drift-sla.cjs (logic stays out of workflow YAML). Slack
       # alerts for the drift/SLA lifecycle are posted INLINE from this watch —
       # not from an issues:-triggered workflow — because this issue is created

--- a/.github/workflows/slack-alerts.yml
+++ b/.github/workflows/slack-alerts.yml
@@ -1,6 +1,6 @@
 name: Slack alerts (SLA review path)
 
-# Deterministic Slack #alert egress for the SLA-lifecycle events that happen
+# Deterministic Slack #alerts egress for the SLA-lifecycle events that happen
 # OUTSIDE the drift watch: automation opening a fix PR (human review is the
 # SLA critical path), automation filing a needs-human issue (the #90 class),
 # and automation publishing an interim patch release.
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   notify:
-    name: Notify #alert (automation events)
+    name: Notify #alerts (automation events)
     # Automation-authored events only — humans already know what they just did.
     # Matches the Claude GitHub App ('claude' / 'claude[bot]').
     if: startsWith(github.actor, 'claude')

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.tar.gz
 *.zip
 .DS_Store
+.tmp/
+.firecrawl/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,10 @@ deadline nears. The autonomous loop ships rebuild-fixable improvements
 and auto-ships a merged source fix on the next daily cycle, so the binding
 constraint is human PR-review latency, not release cadence.
 
-**Slack alerting (SLA lifecycle → #alert):** every SLA transition (drift
+**Slack alerting (SLA lifecycle → #alerts):** every SLA transition (drift
 detected, clock started, at-risk, breached + daily countdown, recovery,
 watch-errored) and every automation-authored review request (fix PR /
-needs-human issue / interim release) posts to the Slack #alert channel.
+needs-human issue / interim release) posts to the Slack #alerts channel.
 Transport is `scripts/slack-alert.sh` (`SLACK_ALERT_WEBHOOK_URL` secret;
 everything **no-ops if unset**; delivery is best-effort and never fails a
 watch — the GitHub issue + labels stay the durable SLA record). Drift/SLA

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: slack-test next-patch-version scout-setup scout-check
 
-# Send a test alert through scripts/slack-alert.sh to verify the Slack #alert
+# Send a test alert through scripts/slack-alert.sh to verify the Slack #alerts
 # webhook wiring end-to-end. No-op (prints a skip) if SLACK_ALERT_WEBHOOK_URL
 # is unset — set it from 1Password when testing locally; in CI it comes from
 # the repo secret of the same name.

--- a/scripts/scout-drift-recovery.cjs
+++ b/scripts/scout-drift-recovery.cjs
@@ -11,7 +11,7 @@
 //
 // Runs when the daily scan came back fully clean (drift == '0'): closes any
 // open `scout-drift` issue so the loop self-resets (drift opens it, recovery
-// closes it), and posts the ✅ all-clear to Slack #alert (best-effort via
+// closes it), and posts the ✅ all-clear to Slack #alerts (best-effort via
 // scripts/slack-alert.sh; no-op without SLACK_ALERT_WEBHOOK_URL).
 'use strict';
 

--- a/scripts/scout-drift-sla.cjs
+++ b/scripts/scout-drift-sla.cjs
@@ -19,7 +19,7 @@
 //   - starts the SLA clock (sla:critical / sla:high label) when fixable C/H
 //     findings appear; escalates sla:at-risk → sla:breached per scout-sla.json
 //     (clock measured from issue creation; breach also fails the run)
-// New: posts Slack #alert messages at each lifecycle transition, plus a daily
+// New: posts Slack #alerts messages at each lifecycle transition, plus a daily
 // countdown while a clock is running. Slack alerts are posted INLINE from the
 // watch (not an issues:-triggered workflow) because this issue is created with
 // the default GITHUB_TOKEN, whose events do NOT trigger other workflows

--- a/scripts/scout-setup.sh
+++ b/scripts/scout-setup.sh
@@ -13,7 +13,7 @@
 #
 # Usage:
 #   scout-setup.sh            enroll the org + enable Scout on every image in
-#                             the JSON (idempotent). Alerts Slack #alert (via
+#                             the JSON (idempotent). Alerts Slack #alerts (via
 #                             scripts/slack-alert.sh, if present) when it had
 #                             to fix a repo that was found disabled.
 #   scout-setup.sh --check    report-only: list desired vs currently-enabled;
@@ -129,7 +129,7 @@ while IFS= read -r img; do
 done <<< "$targets"
 
 # Alert only on a *known* fix (state was readable and a desired repo was found
-# disabled) — that is enrollment drift worth telling #alert about.
+# disabled) — that is enrollment drift worth telling #alerts about.
 if [ "$parse_ok" -eq 1 ] && [ -n "$fixed" ] && [ -f scripts/slack-alert.sh ]; then
   pretty="$(printf "$fixed" | sed '/^$/d' | paste -sd', ' -)"
   bash scripts/slack-alert.sh "⚠️ *Scout enrollment drift* — repo(s) were disabled in Docker Scout and have been re-enabled automatically: ${pretty}. (Un-enrolled repos produce no policy results and silently fall out of the grade gates.)"

--- a/scripts/slack-alert.sh
+++ b/scripts/slack-alert.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# Post a one-line alert to the Slack #alert channel (incoming webhook).
+# Post a one-line alert to the Slack #alerts channel (incoming webhook).
 #
 # Usage:  slack-alert.sh "message text"      (or pipe the message on stdin)
 # Env:    SLACK_ALERT_WEBHOOK_URL — Slack incoming-webhook URL bound to the
-#         #alert channel. Unset ⇒ NO-OP (exit 0), so callers can wire alerting
+#         #alerts channel. Unset ⇒ NO-OP (exit 0), so callers can wire alerting
 #         before the webhook/secret exists and nothing breaks.
 #
 # The message supports Slack mrkdwn: <https://url|label>, *bold*, `code`,


### PR DESCRIPTION
Two small tidy items from the #96 Slack rollout session:

- **Channel name accuracy:** the incoming webhook (Martin app) is bound to **#alerts**, not #alert. Renames every doc/comment/job-name reference (no functional change — the transport just POSTs to `SLACK_ALERT_WEBHOOK_URL`; the webhook decides the channel). Verified end-to-end today: `make slack-test` 🔔 delivered.
- **.gitignore:** local agent scratch dirs `.tmp/` and `.firecrawl/` kept showing up as untracked noise.

Refs #96.