### PR TITLE
ci(scout): alert every red watch run + carve the phantom default-policy-set (#98)

### DIFF
--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -84,6 +84,7 @@ jobs:
             # is the authoritative grade; the raw `cves` probe below is VEX-blind.
             deadline=$(( SECONDS + 900 ))
             policy=""
+            policy_out=""
             while :; do
               rc=0
               out="$(docker scout policy "$ref" --org luthersystems --exit-code 2>&1)" || rc=$?
@@ -100,7 +101,9 @@ jobs:
                 sleep 30
                 continue
               fi
-              policy="❌ below grade A"; drift=1; break
+              # Real violation: defer the drift verdict until the VEX-aware
+              # severity probe below has run — see the #98 carve-out after it.
+              policy_out="$out"; break
             done
 
             # --- Worst fixable severity for the SLA clock (VEX-aware, crash-safe) ---
@@ -121,13 +124,13 @@ jobs:
                   | select([.products[]?."@id" // empty] | map(test("/" + $key + "(@|$)")) | any)
                   | .vulnerability.name' "${vex_dir}"/*.json 2>/dev/null | sort -u || true)"
             fi
-            crit="no"; high="no"
+            crit="no"; high="no"; probe_error=0
             for sev in critical high; do
               set +e
               out="$(docker scout cves "$ref" --only-fixed --only-severity "$sev" --exit-code 2>/dev/null)"; rc=$?
               set -e
               if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
-                echo "::warning::scout cves $sev probe errored (rc=$rc) for $ref"; continue
+                echo "::warning::scout cves $sev probe errored (rc=$rc) for $ref"; probe_error=1; continue
               fi
               [ "$rc" -eq 2 ] || continue   # rc=0 → nothing fixable at this severity
               present="$(printf '%s' "$out" | grep -oE 'CVE-[0-9]{4}-[0-9]+|GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}' | sort -u || true)"
@@ -143,6 +146,29 @@ jobs:
                 if [ "$sev" = critical ]; then crit="yes"; else high="yes"; fi
               fi
             done
+            # --- TEMPORARY carve-out (#98): Docker evaluates the WRONG policy set ---
+            # Since 2026-07-02 the Scout engine applies Docker's DEFAULT policy set
+            # instead of this org's CONFIGURED set: a phantom "Copyleft licensed
+            # packages found" policy (org has AGPL-only; dashboard shows 0
+            # violations) and a fixable-CVE variant that ignores our attached
+            # OpenVEX. Classify a violation as known-mismatch (NOT drift) only when
+            # BOTH hold: (1) every failing policy row is one of those two phantoms,
+            # and (2) if the fixable-CVE row is present, our own fail-closed
+            # VEX-aware probe above CONTRADICTS it (crit=no AND high=no, with no
+            # probe errors). Any other failing row, any real fixable C/H, or an
+            # unparseable policy table stays hard drift. REMOVE when #98 closes.
+            if [ -z "$policy" ]; then
+              failing="$(printf '%s\n' "$policy_out" | grep -E '^[[:space:]]*!.*│' || true)"
+              unexpected="$(printf '%s\n' "$failing" | grep -vE 'Copyleft licensed packages found|Fixable critical or high vulnerabilities found' | sed '/^$/d' || true)"
+              cve_row="$(printf '%s\n' "$failing" | grep -E 'Fixable critical or high vulnerabilities found' || true)"
+              if [ -n "$failing" ] && [ -z "$unexpected" ] \
+                 && { [ -z "$cve_row" ] || { [ "$crit" = "no" ] && [ "$high" = "no" ] && [ "$probe_error" -eq 0 ]; }; }; then
+                policy="⚠️ known policy-set mismatch (#98) — org-configured policies pass"
+                echo "::warning::$ref failed only phantom default-set policies (see #98); not counted as drift"
+              else
+                policy="❌ below grade A"; drift=1
+              fi
+            fi
             if [ "$crit" = "yes" ]; then worst="critical"; fi
             if [ "$high" = "yes" ] && [ "$worst" != "critical" ]; then worst="high"; fi
             echo "- \`${img}\` — ${policy}; fixable Critical: ${crit}, fixable High: ${high}" >> summary.md

--- a/scripts/scout-drift-sla.cjs
+++ b/scripts/scout-drift-sla.cjs
@@ -78,12 +78,16 @@ module.exports = async ({ github, context, core }) => {
   const labelsNow = new Set((issue.labels || []).map(l => (typeof l === 'string' ? l : l.name)));
 
   // No fixable Critical/High behind the drift (e.g. a stale-base-digest policy
-  // only): no CVE SLA clock — the autonomous republish handles it. Alert once
-  // when the issue opens; daily refreshes stay GitHub-only so a lingering
-  // no-clock condition (e.g. a Scout-side evaluation gap) doesn't ping daily.
+  // only): no CVE SLA clock — the autonomous republish handles it. Still alert
+  // EVERY red run, not just the first: a red watch with no Slack ping is
+  // invisible (learned 2026-07-04 — three days of copyleft-drift reds produced
+  // zero alerts because only isNew alerted). The daily cron bounds this to one
+  // message per day.
   if (worst !== 'critical' && worst !== 'high') {
     if (isNew) {
       slack(core, `🟠 *Docker Scout drift* — published buildenv image(s) flagged, but no fixable Critical/High (no SLA clock; the autonomous loop handles it). ${issueRef}`);
+    } else {
+      slack(core, `🟠 *Scout drift continues* — published buildenv image(s) still flagged; no fixable Critical/High (no SLA clock). ${issueRef}`);
     }
     core.info(`Worst fixable severity = ${worst}; no CVE SLA clock.`);
     return;


### PR DESCRIPTION
Fixes the two halves of today's "the watch failed and I got no Slack alert" report. Tracking: #98.

## 1. Why there was no alert (the secret IS set — this was a design gap)

The no-clock branch of `scripts/scout-drift-sla.cjs` alerted only when the drift issue was first **opened**; daily refreshes of an existing no-clock issue were deliberately GitHub-only (an anti-noise choice). Result: three consecutive copyleft-drift reds, zero pings — and the one-shot 🟠 open-alert had fired before the webhook secret existed.

**Fix:** every red run now produces at least one alert — 🟠 *"Scout drift continues"* on no-clock refreshes (the daily cron bounds it to one message/day). Clock-running paths already alerted daily.

## 2. Why it was red (Docker-side, day 3 → carve + support ticket)

Since 2026-07-02 the Scout engine evaluates **Docker's default policy set instead of the org's configured set** (full evidence + support-ticket draft in #98):
- a phantom **"Copyleft licensed packages found"** policy — the org's only license policy is AGPL-only, dashboard shows 0 violations;
- a fixable-CVE variant that **ignores our attached OpenVEX** — flags CVE-2026-34040 on build-godynamic while the same evaluation prints `✓ VEX statements obtained from attestation` (the org-configured policy honored it on Jul 2).

**Fix (temporary, marked `REMOVE when #98 closes`):** the scan defers the drift verdict until the VEX-aware severity probe has run, then classifies a violation as *known-mismatch (not drift)* **only** when every failing row is one of those two phantoms and, if the CVE row is present, our own fail-closed probe contradicts it (`crit=no ∧ high=no ∧ no probe errors`). Any other failing row, any real fixable C/H, a probe error, or an unparseable table stays hard drift.

## Expected behavior after merge

Next run: all 7 images classify as ⚠️ known-mismatch → `drift=0` → the recovery step auto-closes #93 and posts the ✅ all-clear to #alerts (the first organic alert through the new pipeline). Any *real* regression still reds the watch and now always alerts.

Human releases before #98 resolves: use the documented `--only-policy` escape hatch in `publish.yml`'s scout-policy job (untouched here).

## Testing

- Carve classification tested against fixtures from the **real Jul 4 run log**: copyleft-only → carve; copyleft+waived-CVE → carve; real HIGH → drift; probe error → drift; copyleft+outdated-base → drift; unparseable → drift. (The `! 'docker scout policy' is experimental` banner line is proven excluded from row parsing.)
- `sla.cjs` harness: existing no-clock refresh now emits the 🟠 alert; all prior scenarios unchanged.
- `bash -n`, `node --check`, YAML parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3DGesx2gqNgZmxVgTEjY)_