### PR TITLE
Retry transient scout cves probe errors in the drift watch

### DIFF
--- a/.github/workflows/scout-drift.yml
+++ b/.github/workflows/scout-drift.yml
@@ -117,6 +117,14 @@ jobs:
             # OpenVEX, so it would count that waived finding and spoof the SLA
             # severity — subtract this image's not_affected waivers (same jq as
             # scripts/scout-cve-gate.sh) before classifying.
+            # Transient API errors (any rc other than 0/2) get 3 attempts with
+            # 30s backoff: on 2026-07-07 the probe returned rc=1 on 6/7 images
+            # (Docker API hiccup, self-healed by the next run), and because the
+            # #98 carve-out below fail-closes on probe_error, the watch redded
+            # as "below grade A" and opened a false drift issue (#101) for
+            # images whose health hadn't changed. Retries absorb the hiccup;
+            # after exhausted retries the behavior is unchanged (probe_error=1,
+            # fail-closed).
             waived=""
             if compgen -G "${vex_dir}/"'*.json' >/dev/null 2>&1; then
               waived="$(jq -r --arg key "$img" '
@@ -126,11 +134,19 @@ jobs:
             fi
             crit="no"; high="no"; probe_error=0
             for sev in critical high; do
-              set +e
-              out="$(docker scout cves "$ref" --only-fixed --only-severity "$sev" --exit-code 2>/dev/null)"; rc=$?
-              set -e
+              rc=1
+              for attempt in 1 2 3; do
+                set +e
+                out="$(docker scout cves "$ref" --only-fixed --only-severity "$sev" --exit-code 2>/dev/null)"; rc=$?
+                set -e
+                if [ "$rc" -eq 0 ] || [ "$rc" -eq 2 ]; then break; fi
+                if [ "$attempt" -lt 3 ]; then
+                  echo "scout cves $sev probe attempt $attempt errored (rc=$rc) for $ref; retrying in 30s..."
+                  sleep 30
+                fi
+              done
               if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
-                echo "::warning::scout cves $sev probe errored (rc=$rc) for $ref"; probe_error=1; continue
+                echo "::warning::scout cves $sev probe errored (rc=$rc) for $ref after 3 attempts"; probe_error=1; continue
               fi
               [ "$rc" -eq 2 ] || continue   # rc=0 → nothing fixable at this severity
               present="$(printf '%s' "$out" | grep -oE 'CVE-[0-9]{4}-[0-9]+|GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}' | sort -u || true)"


### PR DESCRIPTION
## What

Give the `docker scout cves` severity probe in the daily drift watch 3 attempts with 30s backoff before it gives up, mirroring the retry the policy step already has for "results not ready".

## Why

On 2026-07-07 the drift watch redded and opened a false drift issue (#101). The `docker scout cves` probe returned rc=1 (a transient Docker API error) on 6/7 images, and the fail-closed #98 carve-out correctly refused to classify a policy failure as a known-mismatch without a working probe — so it reported "below grade A" for images whose health had not changed. It self-healed on the next day's run, which auto-closed #101. Actual image health was unaffected throughout (0 fixable Critical/High).

Docker Scout's API is currently flaky (the "Policy data may be delayed" banner tied to #98), so this transient-error class is likely to recur.

## Change

- Wrap the per-severity probe in a 3-attempt loop with 30s backoff.
- rc=0 (clean) or rc=2 (fixable findings) breaks immediately — no behavior change on the success paths.
- Only after 3 failed attempts does it set `probe_error=1` and fall through to the existing fail-closed hard-drift path — identical to today's behavior after exhausted retries.

Classification semantics are otherwise untouched. This is strictly risk-reducing: there is no input for which it is less safe than current `main`.

## Testing

- `.github/workflows/scout-drift.yml` parses as YAML; every `run:` block passes `bash -n`.
- Behaviorally tested the retry loop under `bash -e` with a stubbed probe across 7 scenarios: clean first try, findings first try (rc=2), transient→clean, transient→findings, two errors→clean, persistent rc=1 ×3, and pathological rc=127 ×3. All produce the expected `rc`/attempt-count/`probe_error` and the loop never aborts the step under `-e`.

Refs #98, #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_