### PR TITLE
ci: verify automation-cut publishes, and alert when autofix dies (#109)

### DIFF
--- a/.github/workflows/publish-recovery.yml
+++ b/.github/workflows/publish-recovery.yml
@@ -1,0 +1,60 @@
+name: Publish recovery
+
+# Layer 4 of the grade-A upkeep loop: make sure a release that was CUT actually
+# got PUBLISHED.
+#
+# scout-autofix cuts a patch release and comments "Remediated" — but nothing
+# checked that the publish.yml run the tag triggered succeeded. On 2026-07-31
+# the v0.1.12 publish failed on a transient `docker login` timeout, so `:latest`
+# served the vulnerable v0.1.11 for three days while the drift issue's last word
+# said the CVE was fixed (#107 / #109). A release that never published is worse
+# than no release: the durable SLA record lies.
+#
+# This watches every publish.yml run on a `v*` tag and, on failure, re-runs it
+# once (all publish failures observed so far have been transient registry /
+# module-proxy flake) — then, if the retry also fails, comments on the open
+# `scout-drift` issue and alerts Slack instead of retrying forever.
+#
+# Scope note: this covers ALL `v*` publishes, not just automation-cut ones. A
+# human-cut release is usually watched, so the retry is merely convenient there
+# — but keying off the release author would need an extra lookup and a fallback
+# for tags with no release, and the failure being guarded against is
+# infrastructure, which does not care who cut the tag.
+#
+# Logic lives in scripts/publish-recovery.cjs (CLAUDE.md rule 5); this file is a
+# shim. NOTE: `workflow_run` workflows always run from the DEFAULT BRANCH copy,
+# so edits here only take effect once merged to main.
+on:
+  workflow_run:
+    workflows: ["Build and Push"]
+    types: [completed]
+
+permissions:
+  actions: write # re-run the failed publish jobs
+  issues: write # comment the escalation on the open scout-drift issue
+  contents: read
+
+concurrency:
+  group: publish-recovery-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    name: Retry or escalate a failed publish
+    # Only failed publishes of a version tag. publish.yml is `on: push: tags: ['*']`,
+    # so head_branch carries the tag name (e.g. "v0.1.12").
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'failure' &&
+          startsWith(github.event.workflow_run.head_branch, 'v') }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Retry once, then escalate
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
+        with:
+          script: |
+            const run = require('./scripts/publish-recovery.cjs');
+            await run({ github, context, core });

--- a/.github/workflows/scout-autofix.yml
+++ b/.github/workflows/scout-autofix.yml
@@ -114,6 +114,20 @@ jobs:
           path: ${{ runner.temp }}/claude-execution-output.json
           retention-days: 14
           if-no-files-found: warn
+      # Silence must never look green — the same principle as scout-drift.yml's
+      # "watch errored" alert, which this mirrors. Without it the REMEDIATION
+      # layer can be dead for days with no signal anywhere: on 2026-08-01..03
+      # this job died in <1 min on three consecutive days with a 429 "you've hit
+      # your weekly limit" (subscription-token `seven_day` cap), while an open
+      # sla:high drift issue sat with no fix in flight. Nobody found out until a
+      # human happened to look. See #109 (gap 2) and #82 (Bedrock swap).
+      # Runs last so the trace artifact above is captured first.
+      - name: Alert Slack if autofix itself errored
+        if: failure()
+        env:
+          SLACK_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
+        run: |
+          bash scripts/slack-alert.sh "⚠️ *Scout autofix errored* — the remediation layer failed, so an open \`scout-drift\` issue may have NO fix in flight (its SLA clock keeps running). <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
 
 # ── Bedrock swap (durable billing — see tracking issue #82) ──────────────────
 # 1. Delete the `claude_code_oauth_token:` line above and add to the action `with:`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,13 +62,14 @@ lists fixable C/H findings and drops VEX-waived ones, fail-closed (Scout's own
 `cves --exit-code` can't honor VEX — only `docker scout policy` does). The
 required + exempt sets are the single source of truth in
 [`.github/scout-required-images.json`](.github/scout-required-images.json), gated
-in CI three ways:
+in CI four ways:
 
 | When | Workflow | Gate |
 |---|---|---|
 | every PR | `build.yml` → `cve-scan` + `non-root-audit` | fixable CRITICAL/HIGH CVEs (required set); non-root audit across **all** images — hard-fails only if a required image regresses to root, reports the rest |
 | release (tag) | `publish.yml` → `scout-policy` | `docker scout policy --exit-code` (true grade) + attestations. **Hard for human-cut releases; report-only for automation's interim patch releases** (`release-meta` detects `claude[bot]`) |
 | daily cron | `scout-drift.yml` | re-scan published `:latest`; open/refresh a `scout-drift` issue on drift, auto-close on recovery, and **escalate the remediation SLA** |
+| publish failed | `publish-recovery.yml` | a failed `v*` publish is **re-run once**, then escalated onto the open `scout-drift` issue + Slack. **Cutting a release is not remediating** — v0.1.12's publish died on a transient Docker Hub timeout and `:latest` served the vulnerable build for 3 days while the issue read "Remediated" (#107 → #109) |
 
 **Remediation SLA (customer — [`.github/scout-sla.json`](.github/scout-sla.json)):**
 fixable **Critical → published fix within 15 days**, fixable **High → 30 days**;

--- a/scripts/publish-recovery.cjs
+++ b/scripts/publish-recovery.cjs
@@ -1,0 +1,97 @@
+// Retry-or-escalate a FAILED publish of a tagged release.
+//
+// Loaded by .github/workflows/publish-recovery.yml as a thin shim:
+//
+//   uses: actions/github-script@<pin>
+//   with:
+//     script: |
+//       const run = require('./scripts/publish-recovery.cjs');
+//       await run({ github, context, core });
+//
+// Why this exists (#109, the v0.1.12 / #107 incident):
+// scout-autofix treats `gh release create` as the end of remediation — nothing
+// verified that the publish.yml run the tag triggered actually SUCCEEDED. On
+// 2026-07-31 the v0.1.12 publish died on a transient `docker login` timeout
+// during a Docker Hub wobble; fail-fast cancelled the matrix, push-manifests
+// was skipped, and `:latest` kept serving the vulnerable v0.1.11 for THREE DAYS
+// while the drift issue's last word read "Remediated". A cut release that never
+// published is worse than no release: the durable SLA record says fixed while
+// the fix is not live.
+//
+// Behaviour, keyed on the failed run's attempt number:
+//   attempt 1  → re-run the failed jobs once. Every publish failure seen so far
+//                has been transient infrastructure (Docker Hub login timeout;
+//                proxy.golang.org stream error on v0.1.10), and both cleared on
+//                a plain re-run.
+//   attempt 2+ → do NOT retry again. Comment on every open `scout-drift` issue
+//                (the durable SLA record) and alert Slack, then fail this run so
+//                it is red in the Actions tab. Silence is not green.
+// The attempt check is also the infinite-loop guard: a re-run completes as
+// attempt 2, lands back here, and takes the escalate branch instead.
+'use strict';
+
+const { execFileSync } = require('child_process');
+
+const slack = (core, text) => {
+  try {
+    execFileSync('bash', ['scripts/slack-alert.sh', text], { stdio: 'inherit' });
+  } catch (e) {
+    core.warning(`slack-alert.sh failed: ${e}`);
+  }
+};
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const wr = context.payload.workflow_run;
+  const tag = wr.head_branch;
+  const runUrl = wr.html_url;
+  const attempt = wr.run_attempt;
+
+  if (attempt < 2) {
+    await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: wr.id });
+    core.info(`Publish of ${tag} failed (attempt ${attempt}); re-ran its failed jobs.`);
+    slack(
+      core,
+      `🔁 *Publish failed — auto-retrying* — \`${tag}\` publish failed (attempt ${attempt}); ` +
+        `re-running the failed jobs once. <${runUrl}|View run>`,
+    );
+    return;
+  }
+
+  // Attempt 2+ failed: this is not a transient flake. The images are NOT
+  // published — `:latest` still serves the previous release, so whatever this
+  // release was remediating is still exposed.
+  const body = [
+    `### ⚠️ Publish of \`${tag}\` failed again (attempt ${attempt}) — the fix is **not live**`,
+    '',
+    `The release was cut, but [its publish run](${runUrl}) failed twice, so the images were never pushed.`,
+    '`:latest` still serves the previous release and **this issue\'s SLA clock is still running**.',
+    '',
+    'A single automatic re-run has already been tried and did not clear it, so this needs a human:',
+    'diagnose the publish failure, then either re-run it or cut a fresh patch release.',
+    '',
+    '_Posted by `publish-recovery.yml` (#109)._',
+  ].join('\n');
+
+  const open = await github.rest.issues.listForRepo({
+    owner, repo, state: 'open', labels: 'scout-drift', per_page: 100,
+  });
+  for (const issue of open.data) {
+    await github.rest.issues.createComment({
+      owner, repo, issue_number: issue.number, body,
+    });
+    core.info(`Commented publish failure on scout-drift issue #${issue.number}`);
+  }
+
+  const where = open.data.length
+    ? ` Commented on ${open.data.map((i) => `#${i.number}`).join(', ')}.`
+    : ' (no open scout-drift issue to annotate).';
+  slack(
+    core,
+    `🔴 *Publish FAILED after retry* — \`${tag}\` did not publish (attempt ${attempt}), so ` +
+      `\`:latest\` still serves the previous images and any fix this release carried is NOT live.` +
+      `${where} <${runUrl}|View run>`,
+  );
+
+  core.setFailed(`Publish of ${tag} failed after an automatic retry; escalated.`);
+};


### PR DESCRIPTION
Closes gaps 1 and 2 of #109 — the two blind spots that let the v0.1.12 fix for #107 sit unpublished for three days while the drift issue's last word read "Remediated".

## Gap 1 — a cut release was never verified to have published

`scout-autofix` treats `gh release create` as the end of remediation, but nothing checked that the `publish.yml` run the tag triggered actually succeeded. On 7/31 that run died on a transient `docker login` timeout, fail-fast cancelled the matrix, `push-manifests` was skipped, and `:latest` kept serving the vulnerable v0.1.11.

New `publish-recovery.yml` + `scripts/publish-recovery.cjs`, on a failed `v*` publish:

| Failed run | Action |
|---|---|
| attempt 1 | Re-run the failed jobs once, post a Slack notice |
| attempt 2+ | **Stop retrying.** Comment on every open `scout-drift` issue, alert Slack, fail its own run |

Every publish failure seen so far has been transient infrastructure — the Docker Hub login timeout here, and a `proxy.golang.org` stream error on v0.1.10 — and both cleared on a plain re-run. Keying on `run_attempt` is also the infinite-loop guard: a re-run completes as attempt 2, lands back in this workflow, and takes the escalate branch.

## Gap 2 — scout-autofix failures were silent

`scout-drift.yml` already alerts when the watch itself errors ("silence is not green"); the *remediation* layer had no equivalent. It was dead 8/1–8/3 on three consecutive weekly-limit 429s with no signal anywhere. This mirrors the same `scripts/slack-alert.sh` failure step into `scout-autofix.yml`.

## Scope note

The publish watchdog covers **all** `v*` publishes, not just automation-cut ones. Keying off the release author would need an extra lookup plus a fallback for tags with no release, and the failure being guarded against is infrastructure — which does not care who cut the tag. For a human-cut release the retry is merely convenient.

Gap 3 (the subscription token's weekly limit killing the remediation layer) is not addressed here — that is the Bedrock swap in #82, which needs `ui-infrastructure` work.

## Testing

- `node --check` on the new script; verified it exports an async function.
- Mock-based behavioural test of the decision logic: retry-once on attempt 1; escalate **without** retrying on attempts 2 and 3; comments on all open drift issues; the no-open-issue path does not crash and still fails the run. All 10 assertions pass.
- The Slack path was exercised end-to-end in that test and correctly no-ops without `SLACK_ALERT_WEBHOOK_URL`, per the `slack-alert.sh` contract.
- All 7 workflows still parse as YAML; `bash -n` clean on the changed `run:` blocks.
- Action pins use the repo's current `actions/checkout` / `github-script` SHAs (rule 4); logic lives in `scripts/` with the workflow as a shim (rule 5).

Note: `workflow_run` workflows always run from the **default branch** copy, so this only starts protecting publishes once merged.

Refs #109, #107, #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_