### PR TITLE
scout(build-godynamic): waive CVE-2026-69248, correct the purl and the drop trigger

### DIFF
--- a/.github/vex/build-godynamic.openvex.json
+++ b/.github/vex/build-godynamic.openvex.json
@@ -2,8 +2,8 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://luthersystems.com/vex/buildenv/build-godynamic",
   "author": "Luther Systems (buildenv CI)",
-  "timestamp": "2026-08-06T00:00:00Z",
-  "version": 3,
+  "timestamp": "2026-08-08T00:00:00Z",
+  "version": 4,
   "statements": [
     {
       "vulnerability": {
@@ -14,7 +14,9 @@
         {
           "@id": "pkg:docker/luthersystems/build-godynamic",
           "subcomponents": [
-            { "@id": "pkg:golang/github.com/docker/docker" }
+            {
+              "@id": "pkg:golang/github.com/docker/docker"
+            }
           ]
         }
       ],
@@ -31,13 +33,15 @@
         {
           "@id": "pkg:docker/luthersystems/build-godynamic",
           "subcomponents": [
-            { "@id": "pkg:pypi/cryptography" }
+            {
+              "@id": "pkg:pypi/cryptography"
+            }
           ]
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-69247 is exploitable only against a service that adaptively auto-decrypts attacker-supplied PKCS#7 / S-MIME EnvelopedData at high volume and reflects the outcome -- per the advisory, 'an S/MIME gateway or mail filter'. The vulnerable functions are cryptography's pkcs7_decrypt_der / pkcs7_decrypt_pem / pkcs7_decrypt_smime. build-godynamic bundles cryptography ONLY as a vendored, transitive dependency of two command-line tools: the aws-cli (v2.35.11, its make-exe bundle) and the azure-cli (v2.87.0, /az/venv). Both use cryptography for outbound client operations -- TLS, request signing, token/JWT and key handling -- against AWS/Azure APIs; neither exposes, imports, or invokes the PKCS#7 EnvelopedData decryption path, and the image runs no S/MIME decryption service or adaptive network oracle. The vulnerable code is therefore never reached in the image's execute path. No safe in-place fix lever exists: cryptography is pinned by the vendored CLIs, and force-upgrading it inside their bundled venvs risks breaking the CLIs at runtime (unverifiable in buildenv CI -- see docs/upstream-cve-backlog.md, build-js). Remediation is upstream-gated: drop this statement and bump AWSCLI_VER / AZCLI_VER once both CLIs vendor cryptography >= 50.0.0. NOTE FOR REVIEW: this waiver is scoped strictly to CVE-2026-69247 (the S/MIME EnvelopedData oracle) -- it does NOT waive general cryptography CVEs that az/aws exercise via ordinary crypto operations (those remain execute-path and are handled as exempt elsewhere, e.g. build-js)."
+      "impact_statement": "CVE-2026-69247 is exploitable only against a service that adaptively auto-decrypts attacker-supplied PKCS#7 / S-MIME EnvelopedData at high volume and reflects the outcome -- per the advisory, 'an S/MIME gateway or mail filter'. The vulnerable functions are cryptography's pkcs7_decrypt_der / pkcs7_decrypt_pem / pkcs7_decrypt_smime. build-godynamic bundles cryptography from exactly ONE source: the azure-cli (v2.87.0) virtualenv at /az/venv. (Earlier revisions of this document also named the aws-cli make-exe bundle as a second source. That was wrong: aws-cli 2.35.11 does not depend on cryptography at all -- it uses the native AWS Common Runtime, awscrt 0.32.2. Verified against every requirements file at that tag, which are fully pinned pip-compile --generate-hashes locks, so absence from the lock means absence from the bundle.) Both use cryptography for outbound client operations -- TLS, request signing, token/JWT and key handling -- against AWS/Azure APIs; neither exposes, imports, or invokes the PKCS#7 EnvelopedData decryption path, and the image runs no S/MIME decryption service or adaptive network oracle. The vulnerable code is therefore never reached in the image's execute path. No safe in-place fix lever exists: cryptography is pinned by the vendored CLIs, and force-upgrading it inside their bundled venvs risks breaking the CLIs at runtime (unverifiable in buildenv CI -- see docs/upstream-cve-backlog.md, build-js). REMEDIATION IS UPSTREAM-BLOCKED, and the blocker is precise: azure-cli-core hard-pins msal==1.36.0 (sys_platform != 'win32'), and msal 1.36.0 requires cryptography<49. msal 1.37.0 relaxes that to cryptography<51 -- which would admit 50.0.0 and clear ALL of 69247/69248/69249 at once -- but it is unreachable while azure-cli-core pins 1.36.0. Confirmed by resolution: azure-cli 2.87.0, 2.88.0 and 2.89.0 all resolve msal 1.36.0 -> cryptography 48.0.1, and an explicit `pip install azure-cli==2.87.0 \"cryptography>=50.0.0\"` fails with ResolutionImpossible. So bumping AZCLI_VER does NOT help. DROP TRIGGER: an azure-cli-core release that admits msal >= 1.37.0; then bump AZCLI_VER and delete all three cryptography statements together. Do not expect this soon -- msal 1.37.0 shipped 2026-05-29 and azure-cli-core 2.89.0 (released 2026-08-07) still pins 1.36.0. NOTE FOR REVIEW: this waiver is scoped strictly to CVE-2026-69247 (the S/MIME EnvelopedData oracle) -- it does NOT waive general cryptography CVEs that az/aws exercise via ordinary crypto operations (those remain execute-path and are handled as exempt elsewhere, e.g. build-js)."
     },
     {
       "vulnerability": {
@@ -48,13 +52,34 @@
         {
           "@id": "pkg:docker/luthersystems/build-godynamic",
           "subcomponents": [
-            { "@id": "pkg:pypi/cryptography" }
+            {
+              "@id": "pkg:pypi/cryptography"
+            }
           ]
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-69249 is an availability-only (denial-of-service) algorithmic-complexity flaw in cryptography's X.509 PATH-VALIDATION API -- cryptography.x509.verification (the PolicyBuilder and Server/Client Verifier chain builders). It is triggered only when an application feeds attacker-controlled certificate chains (duplicated issuers, deep paths) into that verifier at volume; there is no confidentiality or integrity impact (CVSS VC:N/VI:N/VA:H). build-godynamic bundles cryptography ONLY as a vendored, transitive dependency of two command-line tools: the aws-cli (v2.35.11, its make-exe bundle) and the azure-cli (v2.87.0, /az/venv). Both use cryptography for OUTBOUND CLIENT operations against AWS/Azure APIs -- request signing, token/JWT and key handling -- while TLS peer-certificate verification goes through Python's ssl module (OpenSSL), NOT cryptography.x509.verification. Neither CLI constructs a cryptography path-validation Verifier over caller-supplied chains, and the image runs no service that adaptively validates attacker-supplied certificate chains, so the vulnerable path validator is never reached in the image's execute path. This waiver is scoped strictly to CVE-2026-69249 (the x509.verification path-builder DoS) -- a distinct, opt-in chain-validation feature the CLIs do not invoke -- and is consistent with, not a widening of, the CVE-2026-69247 note above: it does NOT waive general cryptography CVEs that az/aws exercise via ordinary crypto operations. No safe in-place fix lever exists: cryptography is pinned by the vendored CLIs and force-upgrading it inside their bundled venvs risks breaking the CLIs at runtime (unverifiable in buildenv CI -- see docs/upstream-cve-backlog.md, build-js). Remediation is upstream-gated: drop this statement and bump AWSCLI_VER / AZCLI_VER once both CLIs vendor cryptography >= 49.0.0 (>= 50.0.0 also clears CVE-2026-69247, letting both crypto waivers drop together). NOTE FOR REVIEW: please validate the reachability claim (e.g. grep the vendored aws/az sources for cryptography.x509.verification usage) before merging -- same review posture as CVE-2026-69247 (PR #112)."
+      "impact_statement": "CVE-2026-69249 is an availability-only (denial-of-service) algorithmic-complexity flaw in cryptography's X.509 PATH-VALIDATION API -- cryptography.x509.verification (the PolicyBuilder and Server/Client Verifier chain builders). It is triggered only when an application feeds attacker-controlled certificate chains (duplicated issuers, deep paths) into that verifier at volume; there is no confidentiality or integrity impact (CVSS VC:N/VI:N/VA:H). build-godynamic bundles cryptography from exactly ONE source: the azure-cli (v2.87.0) virtualenv at /az/venv. (Earlier revisions of this document also named the aws-cli make-exe bundle as a second source. That was wrong: aws-cli 2.35.11 does not depend on cryptography at all -- it uses the native AWS Common Runtime, awscrt 0.32.2. Verified against every requirements file at that tag, which are fully pinned pip-compile --generate-hashes locks, so absence from the lock means absence from the bundle.) Both use cryptography for OUTBOUND CLIENT operations against AWS/Azure APIs -- request signing, token/JWT and key handling -- while TLS peer-certificate verification goes through Python's ssl module (OpenSSL), NOT cryptography.x509.verification. Neither CLI constructs a cryptography path-validation Verifier over caller-supplied chains, and the image runs no service that adaptively validates attacker-supplied certificate chains, so the vulnerable path validator is never reached in the image's execute path. This waiver is scoped strictly to CVE-2026-69249 (the x509.verification path-builder DoS) -- a distinct, opt-in chain-validation feature the CLIs do not invoke -- and is consistent with, not a widening of, the CVE-2026-69247 note above: it does NOT waive general cryptography CVEs that az/aws exercise via ordinary crypto operations. No safe in-place fix lever exists: cryptography is pinned by the vendored CLIs and force-upgrading it inside their bundled venvs risks breaking the CLIs at runtime (unverifiable in buildenv CI -- see docs/upstream-cve-backlog.md, build-js). REMEDIATION IS UPSTREAM-BLOCKED, and the blocker is precise: azure-cli-core hard-pins msal==1.36.0 (sys_platform != 'win32'), and msal 1.36.0 requires cryptography<49. msal 1.37.0 relaxes that to cryptography<51 -- which would admit 50.0.0 and clear ALL of 69247/69248/69249 at once -- but it is unreachable while azure-cli-core pins 1.36.0. Confirmed by resolution: azure-cli 2.87.0, 2.88.0 and 2.89.0 all resolve msal 1.36.0 -> cryptography 48.0.1, and an explicit `pip install azure-cli==2.87.0 \"cryptography>=50.0.0\"` fails with ResolutionImpossible. So bumping AZCLI_VER does NOT help. DROP TRIGGER: an azure-cli-core release that admits msal >= 1.37.0; then bump AZCLI_VER and delete all three cryptography statements together. Do not expect this soon -- msal 1.37.0 shipped 2026-05-29 and azure-cli-core 2.89.0 (released 2026-08-07) still pins 1.36.0. NOTE FOR REVIEW: please validate the reachability claim (e.g. grep the vendored aws/az sources for cryptography.x509.verification usage) before merging -- same review posture as CVE-2026-69247 (PR #112)."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-69248",
+        "description": "pyca/cryptography X.509 verifier accepts wildcard DNS names that escape a permitted-subtree name constraint: if an intermediate constrained CA permits the DNS name foo.example.com and the leaf presents a wildcard SAN of *.example.com, cryptography's verifier accepts it, allowing escape from permittedSubtrees. Integrity impact -- CVSS 4.0 vector .../VC:L/VI:H/VA:N. Affects <49.0.0; fixed in cryptography 49.0.0."
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/luthersystems/build-godynamic",
+          "subcomponents": [
+            {
+              "@id": "pkg:pypi/cryptography"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-69248 is a name-constraint bypass in the SAME cryptography X.509 path-validation API as CVE-2026-69249 -- cryptography.x509.verification (PolicyBuilder / Server- and ClientVerifier). Unlike 69249 it is an INTEGRITY issue rather than availability-only (CVSS VC:L/VI:H/VA:N): a leaf with a wildcard SAN can escape an intermediate CA's permittedSubtrees. The reachability analysis is identical to 69249 and holds for the same reason. build-godynamic bundles cryptography from exactly ONE source: the azure-cli (v2.87.0) virtualenv at /az/venv. (Earlier revisions of this document also named the aws-cli make-exe bundle as a second source. That was wrong: aws-cli 2.35.11 does not depend on cryptography at all -- it uses the native AWS Common Runtime, awscrt 0.32.2. Verified against every requirements file at that tag, which are fully pinned pip-compile --generate-hashes locks, so absence from the lock means absence from the bundle.) azure-cli uses cryptography for OUTBOUND CLIENT operations against Azure APIs -- request signing, token/JWT and key handling -- while TLS peer-certificate verification goes through Python's ssl module (OpenSSL), NOT cryptography.x509.verification. It never constructs a path-validation Verifier over caller-supplied chains, and the image runs no service that validates attacker-supplied certificate chains, so the vulnerable verifier is never reached in the image's execute path. RECORDED DELIBERATELY EVEN THOUGH IT DOES NOT CURRENTLY GATE: scripts/scout-cve-gate.sh fails only on fixable CRITICAL/HIGH, and this rates below that threshold, so it is invisible to CI today. It was found by auditing the full advisory set for cryptography 48.0.1 rather than by the gate, and is recorded here so the position is documented and the gate does not turn red without explanation if Scout ever re-rates it. REMEDIATION IS UPSTREAM-BLOCKED, and the blocker is precise: azure-cli-core hard-pins msal==1.36.0 (sys_platform != 'win32'), and msal 1.36.0 requires cryptography<49. msal 1.37.0 relaxes that to cryptography<51 -- which would admit 50.0.0 and clear ALL of 69247/69248/69249 at once -- but it is unreachable while azure-cli-core pins 1.36.0. Confirmed by resolution: azure-cli 2.87.0, 2.88.0 and 2.89.0 all resolve msal 1.36.0 -> cryptography 48.0.1, and an explicit `pip install azure-cli==2.87.0 \"cryptography>=50.0.0\"` fails with ResolutionImpossible. So bumping AZCLI_VER does NOT help. DROP TRIGGER: an azure-cli-core release that admits msal >= 1.37.0; then bump AZCLI_VER and delete all three cryptography statements together. Do not expect this soon -- msal 1.37.0 shipped 2026-05-29 and azure-cli-core 2.89.0 (released 2026-08-07) still pins 1.36.0."
     }
   ]
 }

--- a/docs/upstream-cve-backlog.md
+++ b/docs/upstream-cve-backlog.md
@@ -99,6 +99,72 @@ releases that vendor `cryptography >= 50.0.0`, confirm the finding is gone, and
 **delete the CVE-2026-69247 statement** from
 `.github/vex/build-godynamic.openvex.json`. No required/exempt change.
 
+### Correction, and the real blocker (2026-08-08)
+
+Two things above are wrong or incomplete, corrected here and in
+`.github/vex/build-godynamic.openvex.json` (v4).
+
+**1. aws-cli does not vendor `cryptography` at all.** The 69247/69249 notes name
+two purls — the aws-cli `make-exe` bundle and the azure-cli `/az/venv`. Only the
+second exists. `aws-cli` at tag `2.35.11` uses the native AWS Common Runtime
+(`awscrt 0.32.2`); `cryptography` appears in none of its requirements files, and
+those are fully-pinned `pip-compile --generate-hashes` locks, so absence from the
+lock means absence from the bundle. **The azure-cli venv is the only source.**
+
+**2. The drop trigger is not a CLI bump.** Recorded as "bump `AWSCLI_VER` /
+`AZCLI_VER` once both vendor `cryptography >= 50.0.0`" and noted as unverifiable
+offline. It is verifiable, and a CLI bump does not work:
+
+```
+azure-cli-core 2.89.0  ->  msal==1.36.0   (hard pin, sys_platform != "win32")
+msal 1.36.0            ->  cryptography<49,>=2.5
+                       ->  48.0.1 is the newest admissible version
+```
+
+Confirmed by resolution: `azure-cli` **2.87.0, 2.88.0 and 2.89.0 all** resolve
+`msal 1.36.0` -> `cryptography 48.0.1`. Forcing it fails outright:
+
+```
+$ pip install --dry-run "azure-cli==2.87.0" "cryptography>=50.0.0"
+ERROR: ResolutionImpossible
+  The user requested cryptography>=50.0.0
+  msal 1.36.0 depends on cryptography<49 and >=2.5
+```
+
+`msal 1.37.0` already relaxes this to `cryptography<51` — which admits 50.0.0 and
+clears **all three** crypto CVEs at once — but it is unreachable while
+azure-cli-core pins 1.36.0.
+
+**Actual drop trigger:** an `azure-cli-core` release admitting `msal >= 1.37.0`.
+Then bump `AZCLI_VER` and delete all three cryptography statements together.
+**Do not expect this soon:** msal 1.37.0 shipped 2026-05-29, and azure-cli-core
+2.89.0 — released 2026-08-07 — still pins 1.36.0.
+
+### CVE-2026-69248 — cryptography 48.0.1 (azure-cli vendored) — below gate threshold
+
+Found by auditing the full advisory set for `cryptography 48.0.1`, **not** by the
+gate. `48.0.1` carries three advisories, not the two tracked above:
+
+| CVE | Impact | Fixed in |
+|---|---|---|
+| 69247 | PKCS#7 / S-MIME decrypt oracle | 50.0.0 |
+| 69249 | `VC:N/VI:N/VA:H` — availability only | 49.0.0 |
+| **69248** | **`VC:L/VI:H/VA:N` — integrity** | 49.0.0 |
+
+CVE-2026-69248 lets a leaf certificate with a wildcard SAN (`*.example.com`)
+escape an intermediate CA's `permittedSubtrees` constraint (`foo.example.com`) —
+an *integrity* failure in the verifier, arguably more serious than the
+availability-only DoS that triggered the alert.
+
+It is invisible to CI because `scripts/scout-cve-gate.sh` iterates
+`for sev in critical high` and this rates below that. The gate is behaving as
+designed; the design has a blind spot for Medium-rated integrity findings.
+
+It lives in the same `cryptography.x509.verification` API as 69249, so the same
+reachability reasoning applies unchanged, and the same upstream blocker gates the
+fix. Recorded as a VEX statement so the position is documented and the gate
+cannot turn red without explanation if Scout re-rates it.
+
 ### CVE-2026-69249 — cryptography 48.0.1 (aws-cli + azure-cli vendored) — HIGH
 
 Surfaced by the 2026-08-06 daily drift watch (issue #111), on the **same**


### PR DESCRIPTION
Follow-up to #113. Three corrections to the `build-godynamic` cryptography position — all found by auditing the advisory set and resolving the dependency graph, none by the gate.

## 1. There is a third CVE, and it is the more serious one

`cryptography 48.0.1` carries **three** advisories, not the two tracked:

| CVE | Impact | Fixed in | Tracked before? |
|---|---|---|---|
| 69247 | PKCS#7 / S-MIME decrypt oracle | 50.0.0 | ✅ #112 |
| 69249 | `VC:N/VI:N/VA:H` — availability only | 49.0.0 | ✅ #113 |
| **69248** | **`VC:L/VI:H/VA:N` — integrity** | 49.0.0 | ❌ |

**CVE-2026-69248** lets a leaf certificate with a wildcard SAN (`*.example.com`) escape an intermediate CA's `permittedSubtrees` constraint (`foo.example.com`). That's an *integrity* failure in the verifier — arguably more serious than the availability-only DoS that triggered the alert in the first place.

It is invisible to CI because `scripts/scout-cve-gate.sh` iterates `for sev in critical high` and this rates below that threshold. **The gate is behaving exactly as designed** — the design has a blind spot for Medium-rated integrity findings, which is worth knowing independently of this PR.

It lives in the same `cryptography.x509.verification` API as 69249, so the reachability reasoning carries over unchanged. Added as a scoped `not_affected` statement (VEX v3 → v4) so the position is documented and the gate can't turn red without explanation if Scout re-rates it.

## 2. The purl attribution was wrong

The 69247 and 69249 statements both say cryptography is vendored by "the aws-cli (its make-exe bundle) and the azure-cli (`/az/venv`)". **The aws-cli half is not true.**

`aws-cli` at tag `2.35.11` does not depend on `cryptography` at all — it uses the native AWS Common Runtime, `awscrt 0.32.2`:

```
$ git ls-tree -r --name-only 2.35.11 | grep -E "^requirements" \
    | xargs -I{} sh -c 'git show 2.35.11:{} | grep -i cryptography'
(no matches)

$ git show 2.35.11:requirements/download-deps/portable-exe-lock.txt | head
awscrt==0.32.2 \
```

Those are fully-pinned `pip-compile --generate-hashes` locks, so absence from the lock means absence from the bundle. **The azure-cli venv is the only source.** Corrected in both existing statements — a VEX whose justification reasons about a code path that isn't in the image is a liability in an audit.

## 3. The drop trigger was wrong, and is now precise

Recorded as "bump `AWSCLI_VER`/`AZCLI_VER` once both vendor `cryptography >= 50.0.0`", noted as unverifiable offline. It is verifiable, and **a CLI bump does not work**:

```
azure-cli-core 2.89.0  ->  msal==1.36.0   (hard pin, sys_platform != "win32")
msal 1.36.0            ->  cryptography<49,>=2.5
                       ->  48.0.1 is the newest admissible version
```

`azure-cli` **2.87.0, 2.88.0 and 2.89.0 all** resolve `msal 1.36.0` → `cryptography 48.0.1`. Forcing a floor fails outright:

```
$ pip install --dry-run "azure-cli==2.87.0" "cryptography>=50.0.0"
ERROR: ResolutionImpossible
  The user requested cryptography>=50.0.0
  msal 1.36.0 depends on cryptography<49 and >=2.5
```

`msal 1.37.0` already relaxes this to `cryptography<51` — which admits 50.0.0 and clears **all three** CVEs at once — but it's unreachable behind that pin.

**Real drop trigger:** an `azure-cli-core` release admitting `msal >= 1.37.0`. Then bump `AZCLI_VER` and delete all three cryptography statements together.

**Don't expect it soon:** msal 1.37.0 shipped **2026-05-29**; azure-cli-core 2.89.0, released **2026-08-07**, still pins 1.36.0. Azure cut a release ten weeks after the fix landed and didn't take it. These waivers will be load-bearing for a while.

## Verification

The gate's own jq extraction now returns all four waived IDs:

```
$ jq -r --arg key "build-godynamic" '.statements[]? | select(.status=="not_affected")
    | select([.products[]?."@id" // empty] | map(test("/" + $key + "(@|$)")) | any)
    | .vulnerability.name' .github/vex/build-godynamic.openvex.json | sort -u
CVE-2026-34040
CVE-2026-69247
CVE-2026-69248
CVE-2026-69249
```

JSON validates. No behaviour change for the three already-waived CVEs; 69248 doesn't currently gate, so this is documentation plus future-proofing rather than a grade change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_